### PR TITLE
Fix run shortcut memoization and remap continue to `q`

### DIFF
--- a/components/Editor/ExecutionStatus.tsx
+++ b/components/Editor/ExecutionStatus.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from 'react'
+import { useContext } from 'react'
 
 import { useRegisterActions } from 'kbar'
 
@@ -10,31 +10,28 @@ const ExecutionStatus = () => {
   const { isExecuting, executionState, nextExecution, continueExecution } =
     useContext(EthereumContext)
 
-  const actions = useMemo(
-    () => [
-      {
-        id: 'step',
-        name: 'Step',
-        shortcut: ['s'],
-        keywords: 'execution next',
-        section: 'Execution',
-        perform: nextExecution,
-        subtitle: 'Run next execution',
-      },
-      {
-        id: 'continue',
-        name: 'Continue',
-        shortcut: ['c'],
-        keywords: 'execution continue',
-        section: 'Execution',
-        perform: continueExecution,
-        subtitle: 'Continue execution',
-      },
-    ],
-    [nextExecution, continueExecution],
-  )
+  const actions = [
+    {
+      id: 'step',
+      name: 'Step',
+      shortcut: ['s'],
+      keywords: 'execution next',
+      section: 'Execution',
+      perform: nextExecution,
+      subtitle: 'Run next execution',
+    },
+    {
+      id: 'continue',
+      name: 'Continue',
+      shortcut: ['q'],
+      keywords: 'execution continue',
+      section: 'Execution',
+      perform: continueExecution,
+      subtitle: 'Continue execution',
+    },
+  ]
 
-  useRegisterActions(actions)
+  useRegisterActions(actions, [nextExecution, continueExecution])
 
   return (
     <div className="flex flex-grow justify-between items-center text-sm">

--- a/components/Editor/Header.tsx
+++ b/components/Editor/Header.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo, ChangeEvent } from 'react'
+import { useContext, ChangeEvent } from 'react'
 
 import { useRegisterActions } from 'kbar'
 
@@ -23,22 +23,19 @@ const EditorHeader = ({
 }: Props) => {
   const { selectedFork } = useContext(EthereumContext)
 
-  const actions = useMemo(
-    () => [
-      {
-        id: 'run',
-        name: 'Run',
-        shortcut: ['r'],
-        keywords: 'execution run',
-        section: 'Execution',
-        perform: onRun,
-        subtitle: 'Start execution',
-      },
-    ],
-    [onRun],
-  )
+  const actions = [
+    {
+      id: 'run',
+      name: 'Run',
+      shortcut: ['r'],
+      keywords: 'execution run',
+      section: 'Execution',
+      perform: onRun,
+      subtitle: 'Start execution',
+    },
+  ]
 
-  useRegisterActions(actions)
+  useRegisterActions(actions, [onRun])
 
   return (
     <div className="flex justify-between items-center w-full">


### PR DESCRIPTION
- Fixes an issue when on Linux pressing `c` twice while holding Ctrl
would fire an action.
- Fixes a memoization issue with action callbacks, preventing execution

Fixes #42