### PR TITLE
fix: wrong `topic_count` value for `log` opcodes

### DIFF
--- a/docs/opcodes/A0/homestead.mdx
+++ b/docs/opcodes/A0/homestead.mdx
@@ -3,5 +3,5 @@
     static_gas = {gasPrices|log}
     dynamic_gas = {gasPrices|logTopic} * topic_count + {gasPrices|logData} * size + memory_expansion_cost
 
-For LOG0, `topic_count` is 0.
+For LOG0, `topic_count` is 1.
 The memory expansion cost explanation can be found [here](/about).

--- a/docs/opcodes/A1/homestead.mdx
+++ b/docs/opcodes/A1/homestead.mdx
@@ -3,5 +3,5 @@
     static_gas = {gasPrices|log}
     dynamic_gas = {gasPrices|logTopic} * topic_count + {gasPrices|logData} * size + memory_expansion_cost
 
-For LOG1, `topic_count` is 1.
+For LOG1, `topic_count` is 2.
 The memory expansion cost explanation can be found [here](/about).

--- a/docs/opcodes/A2/homestead.mdx
+++ b/docs/opcodes/A2/homestead.mdx
@@ -3,5 +3,5 @@
     static_gas = {gasPrices|log}
     dynamic_gas = {gasPrices|logTopic} * topic_count + {gasPrices|logData} * size + memory_expansion_cost
 
-For LOG2, `topic_count` is 2.
+For LOG2, `topic_count` is 3.
 The memory expansion cost explanation can be found [here](/about).

--- a/docs/opcodes/A3/homestead.mdx
+++ b/docs/opcodes/A3/homestead.mdx
@@ -3,5 +3,5 @@
     static_gas = {gasPrices|log}
     dynamic_gas = {gasPrices|logTopic} * topic_count + {gasPrices|logData} * size + memory_expansion_cost
 
-For LOG3, `topic_count` is 3.
+For LOG3, `topic_count` is 4.
 The memory expansion cost explanation can be found [here](/about).

--- a/docs/opcodes/A4/homestead.mdx
+++ b/docs/opcodes/A4/homestead.mdx
@@ -3,5 +3,5 @@
     static_gas = {gasPrices|log}
     dynamic_gas = {gasPrices|logTopic} * topic_count + {gasPrices|logData} * size + memory_expansion_cost
 
-For LOG4, `topic_count` is 4.
+For LOG4, `topic_count` is 5.
 The memory expansion cost explanation can be found [here](/about).


### PR DESCRIPTION
I think the `topic_count` values of `log` opcodes are wrong.

Here's a quick example with [`log0`](https://www.evm.codes/#a0?fork=shanghai).
- The minimum gas cost is 375
- The dynamic gas cost is given by the formula `dynamic_gas = 375 * topic_count + 8 * size + memory_expansion_cost`
- It is said that for `log0`,  `topic_count` is equal to 0. I think it should be 1 in this case instead.

<img width="1243" alt="Screenshot 2023-06-16 at 10 34 50" src="https://github.com/smlxl/evm.codes/assets/28714795/5375e0f0-cc17-4204-9f90-18d201ff2b7b">
<img width="626" alt="Screenshot 2023-06-16 at 10 34 59" src="https://github.com/smlxl/evm.codes/assets/28714795/bb3ba564-0dfa-4e55-8b96-b6f8e00b603b">
