### PR TITLE
doc: improve dynamic gas computation

### DIFF
--- a/docs/opcodes/0A/homestead.mdx
+++ b/docs/opcodes/0A/homestead.mdx
@@ -1,5 +1,6 @@
 ## Gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|exp}
     dynamic_gas = {gasPrices|expByte} * exponent_byte_size
 

--- a/docs/opcodes/20/homestead.mdx
+++ b/docs/opcodes/20/homestead.mdx
@@ -2,6 +2,7 @@
 
     minimum_word_size = (size + 31) / 32
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|sha3}
     dynamic_gas = {gasPrices|sha3Word} * minimum_word_size + memory_expansion_cost
 

--- a/docs/opcodes/31/berlin.mdx
+++ b/docs/opcodes/31/berlin.mdx
@@ -1,3 +1,9 @@
 ## Gas
 
-The static cost is {gasPrices|balance}. If the accessed address is warm, the dynamic cost is {gasPrices|warmstorageread}. Otherwise the dynamic cost is {gasPrices|coldaccountaccess}. See section [access sets](/about).
+    gas_cost = static_gas + dynamic_gas
+    static_gas = {gasPrices|balance}
+    dynamic_gas =
+        {gasPrices|warmstorageread} if the accessed address is warm
+        {gasPrices|coldaccountaccess} otherwise
+
+See section [access sets](/about).

--- a/docs/opcodes/37/homestead.mdx
+++ b/docs/opcodes/37/homestead.mdx
@@ -2,6 +2,7 @@
 
     minimum_word_size = (size + 31) / 32
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|calldatacopy}
     dynamic_gas = {gasPrices|copy} * minimum_word_size + memory_expansion_cost
 

--- a/docs/opcodes/39/homestead.mdx
+++ b/docs/opcodes/39/homestead.mdx
@@ -2,6 +2,7 @@
 
     minimum_word_size = (size + 31) / 32
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|codecopy}
     dynamic_gas = {gasPrices|copy} * minimum_word_size + memory_expansion_cost
 

--- a/docs/opcodes/3B/berlin.mdx
+++ b/docs/opcodes/3B/berlin.mdx
@@ -1,3 +1,9 @@
 ## Gas
 
-The static cost is {gasPrices|extcodesize}. If the accessed address is warm, the dynamic cost is {gasPrices|warmstorageread}. Otherwise the dynamic cost is {gasPrices|coldaccountaccess}. See section [access sets](/about).
+    gas_cost = static_gas + dynamic_gas
+    static_gas = {gasPrices|extcodesize}
+    dynamic_gas =
+        {gasPrices|warmstorageread} if the accessed address is warm
+        {gasPrices|coldaccountaccess} otherwise
+
+See section [access sets](/about).

--- a/docs/opcodes/3C/berlin.mdx
+++ b/docs/opcodes/3C/berlin.mdx
@@ -2,6 +2,7 @@
 
     minimum_word_size = (size + 31) / 32
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|extcodecopy}
     dynamic_gas = {gasPrices|copy} * minimum_word_size + memory_expansion_cost + address_access_cost
 

--- a/docs/opcodes/3C/homestead.mdx
+++ b/docs/opcodes/3C/homestead.mdx
@@ -2,6 +2,7 @@
 
     minimum_word_size = (size + 31) / 32
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|extcodecopy}
     dynamic_gas = {gasPrices|copy} * minimum_word_size + memory_expansion_cost
 

--- a/docs/opcodes/3E/homestead.mdx
+++ b/docs/opcodes/3E/homestead.mdx
@@ -2,6 +2,7 @@
 
     minimum_word_size = (size + 31) / 32
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|returndatacopy}
     dynamic_gas = {gasPrices|copy} * minimum_word_size + memory_expansion_cost
 

--- a/docs/opcodes/3F/berlin.mdx
+++ b/docs/opcodes/3F/berlin.mdx
@@ -1,3 +1,9 @@
 ## Gas
 
-The static cost is {gasPrices|extcodehash}. If the accessed address is warm, the dynamic cost is {gasPrices|warmstorageread}. Otherwise the dynamic cost is {gasPrices|coldaccountaccess}. See section [access sets](/about).
+  gas_cost = static_gas + dynamic_gas
+  static_gas = {gasPrices|extcodehash}
+  dynamic_gas =
+    {gasPrices|warmstorageread} if the accessed adress is warm
+    {gasPrices|coldaccountaccess} otherwise
+
+See section [access sets](/about).

--- a/docs/opcodes/51/homestead.mdx
+++ b/docs/opcodes/51/homestead.mdx
@@ -1,5 +1,6 @@
 ## Gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|mload}
     dynamic_gas = memory_expansion_cost
 

--- a/docs/opcodes/52/homestead.mdx
+++ b/docs/opcodes/52/homestead.mdx
@@ -1,5 +1,6 @@
 ## Gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|mstore}
     dynamic_gas = memory_expansion_cost
 

--- a/docs/opcodes/53/homestead.mdx
+++ b/docs/opcodes/53/homestead.mdx
@@ -1,5 +1,6 @@
 ## Gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|mstore8}
     dynamic_gas = memory_expansion_cost
 

--- a/docs/opcodes/54/berlin.mdx
+++ b/docs/opcodes/54/berlin.mdx
@@ -1,3 +1,9 @@
 ## Gas
 
-The static cost is {gasPrices|sload}. If the accessed address is warm, the dynamic cost is {gasPrices|warmstorageread}. Otherwise the dynamic cost is {gasPrices|coldsload}. See section [access sets](/about).
+    gas_cost = static_gas + dynamic_gas
+    static_gas = {gasPrices|sload}
+    dynamic_gas =
+        {gasPrices|warmstorageread} if the accessed address is warm
+        {gasPrices|coldsload} otherwise
+
+See section [access sets](/about).

--- a/docs/opcodes/55/berlin.mdx
+++ b/docs/opcodes/55/berlin.mdx
@@ -5,9 +5,10 @@
 - **current_value**: current value of the storage slot.
 - **original_value**: value of the storage slot before the current transaction.
 
-
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|sstore}
-
+    dynamic_gas = base_dynamic_gas + variable_dynamic_gas
+    
     if value == current_value
         if key is warm
             base_dynamic_gas = {gasPrices|warmstorageread}
@@ -21,7 +22,11 @@
     else
         base_dynamic_gas = {gasPrices|sstoreDirtyGasEIP2200}
 
-On top of the cost above, {gasPrices|coldsload} is added to `base_dynamic_gas` if the slot is cold. See section [access sets](/about).
+    variable_dynamic_gas =
+        {gasPrices|coldsload} if the slot is cold
+        0 otherwise
+
+See section [access sets](/about).
 
 ## Gas refunds
 

--- a/docs/opcodes/55/constantinople.mdx
+++ b/docs/opcodes/55/constantinople.mdx
@@ -5,7 +5,7 @@
 - **current_value**: current value of the storage slot.
 - **original_value**: value of the storage slot before the current transaction.
 
-
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|sstore}
 
     if value == current_value

--- a/docs/opcodes/55/istanbul.mdx
+++ b/docs/opcodes/55/istanbul.mdx
@@ -5,7 +5,7 @@
 - **current_value**: current value of the storage slot.
 - **original_value**: value of the storage slot before the current transaction.
 
-
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|sstore}
 
     if value == current_value

--- a/docs/opcodes/55/petersburg.mdx
+++ b/docs/opcodes/55/petersburg.mdx
@@ -1,6 +1,10 @@
 ## Gas
 
-The static cost is {gasPrices|sstore}. If the value is changed from zero to non-zero, then the dynamic gas is {gasPrices|sstoreSet}. Otherwise the dynamic gas  is {gasPrices|sstoreReset}.
+    gas_cost = static_gas + dynamic_gas
+    static_gas = {gasPrices|sstore}
+    dynamic_gas =
+        {gasPrices|sstoreSet} if the value is changed from zero to non-zero
+        {gasPrices|sstoreReset} otherwise
 
 ## Gas refunds
 

--- a/docs/opcodes/A0/homestead.mdx
+++ b/docs/opcodes/A0/homestead.mdx
@@ -1,5 +1,6 @@
 ## Gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|log}
     dynamic_gas = {gasPrices|logTopic} * topic_count + {gasPrices|logData} * size + memory_expansion_cost
 

--- a/docs/opcodes/A1/homestead.mdx
+++ b/docs/opcodes/A1/homestead.mdx
@@ -1,5 +1,6 @@
 ## Dynamic gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|log}
     dynamic_gas = {gasPrices|logTopic} * topic_count + {gasPrices|logData} * size + memory_expansion_cost
 

--- a/docs/opcodes/A2/homestead.mdx
+++ b/docs/opcodes/A2/homestead.mdx
@@ -1,5 +1,6 @@
 ## Dynamic gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|log}
     dynamic_gas = {gasPrices|logTopic} * topic_count + {gasPrices|logData} * size + memory_expansion_cost
 

--- a/docs/opcodes/A3/homestead.mdx
+++ b/docs/opcodes/A3/homestead.mdx
@@ -1,5 +1,6 @@
 ## Dynamic gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|log}
     dynamic_gas = {gasPrices|logTopic} * topic_count + {gasPrices|logData} * size + memory_expansion_cost
 

--- a/docs/opcodes/A4/homestead.mdx
+++ b/docs/opcodes/A4/homestead.mdx
@@ -1,5 +1,6 @@
 ## Dynamic gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|log}
     dynamic_gas = {gasPrices|logTopic} * topic_count + {gasPrices|logData} * size + memory_expansion_cost
 

--- a/docs/opcodes/F0/berlin.mdx
+++ b/docs/opcodes/F0/berlin.mdx
@@ -2,6 +2,7 @@
 
     code_deposit_cost = {gasPrices|createData} * deployed_code_size
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|create}
     dynamic_gas = memory_expansion_cost + deployment_code_execution_cost + code_deposit_cost
 

--- a/docs/opcodes/F0/homestead.mdx
+++ b/docs/opcodes/F0/homestead.mdx
@@ -2,6 +2,7 @@
 
     code_deposit_cost = {gasPrices|createData} * deployed_code_size
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|create}
     dynamic_gas = memory_expansion_cost + deployment_code_execution_cost + code_deposit_cost
 

--- a/docs/opcodes/F1/berlin.mdx
+++ b/docs/opcodes/F1/berlin.mdx
@@ -1,5 +1,6 @@
 ## Gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|call}
     dynamic_gas = memory_expansion_cost + code_execution_cost + address_access_cost + positive_value_cost + value_to_empty_account_cost
 

--- a/docs/opcodes/F1/homestead.mdx
+++ b/docs/opcodes/F1/homestead.mdx
@@ -1,5 +1,6 @@
 ## Gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|call}
     dynamic_gas = memory_expansion_cost + code_execution_cost + positive_value_cost + empty_account_cost
 

--- a/docs/opcodes/F1/spuriousDragon.mdx
+++ b/docs/opcodes/F1/spuriousDragon.mdx
@@ -1,5 +1,6 @@
 ## Gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|call}
     dynamic_gas = memory_expansion_cost + code_execution_cost + positive_value_cost + value_to_empty_account_cost
 

--- a/docs/opcodes/F2/berlin.mdx
+++ b/docs/opcodes/F2/berlin.mdx
@@ -1,5 +1,6 @@
 ## Gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|call}
     dynamic_gas = memory_expansion_cost + code_execution_cost + address_access_cost + positive_value_cost
 

--- a/docs/opcodes/F2/homestead.mdx
+++ b/docs/opcodes/F2/homestead.mdx
@@ -1,5 +1,6 @@
 ## Gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|call}
     dynamic_gas = memory_expansion_cost + code_execution_cost + positive_value_cost
 

--- a/docs/opcodes/F3/homestead.mdx
+++ b/docs/opcodes/F3/homestead.mdx
@@ -1,5 +1,6 @@
 ## Gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|return}
     dynamic_gas = memory_expansion_cost
 

--- a/docs/opcodes/F4/berlin.mdx
+++ b/docs/opcodes/F4/berlin.mdx
@@ -1,5 +1,6 @@
 ## Gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|call}
     dynamic_gas = memory_expansion_cost + code_execution_cost + address_access_cost
 

--- a/docs/opcodes/F4/homestead.mdx
+++ b/docs/opcodes/F4/homestead.mdx
@@ -1,5 +1,6 @@
 ## Gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|call}
     dynamic_gas = memory_expansion_cost + code_execution_cost
 

--- a/docs/opcodes/F5/berlin.mdx
+++ b/docs/opcodes/F5/berlin.mdx
@@ -3,6 +3,7 @@
     minimum_word_size = (size + 31) / 32
     code_deposit_cost = {gasPrices|createData} * deployed_code_size
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|create}
     dynamic_gas = {gasPrices|sha3Word} * minimum_word_size + memory_expansion_cost + deployment_code_execution_cost + code_deposit_cost
 

--- a/docs/opcodes/F5/constantinople.mdx
+++ b/docs/opcodes/F5/constantinople.mdx
@@ -3,6 +3,7 @@
     minimum_word_size = (size + 31) / 32
     code_deposit_cost = {gasPrices|createData} * deployed_code_size
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|create}
     dynamic_gas = {gasPrices|sha3Word} * minimum_word_size + memory_expansion_cost + deployment_code_execution_cost + code_deposit_cost
 

--- a/docs/opcodes/FA/berlin.mdx
+++ b/docs/opcodes/FA/berlin.mdx
@@ -1,5 +1,6 @@
 ## Gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|call}
     dynamic_gas = memory_expansion_cost + code_execution_cost + address_access_cost
 

--- a/docs/opcodes/FA/homestead.mdx
+++ b/docs/opcodes/FA/homestead.mdx
@@ -1,5 +1,6 @@
 ## Gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|call}
     dynamic_gas = memory_expansion_cost + code_execution_cost
 

--- a/docs/opcodes/FD/homestead.mdx
+++ b/docs/opcodes/FD/homestead.mdx
@@ -1,5 +1,6 @@
 ## Gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|return}
     dynamic_gas = memory_expansion_cost
 

--- a/docs/opcodes/FF/berlin.mdx
+++ b/docs/opcodes/FF/berlin.mdx
@@ -1,6 +1,14 @@
 ## Gas
 
-The static gas is {gasPrices|selfdestruct}. If a positive balance is sent to an empty account, the dynamic gas is {gasPrices|callNewAccount}. An account is empty if its balance is 0, its nonce is 0 and it has no code. Additionally, if `address` is cold, there is an additional dynamic cost of {gasPrices|coldaccountaccess}. See section [access sets](/about). There is no additional cost otherwise.
+    gas_cost = static_gas + dynamic_gas
+    static_gas = {gasPrices|selfdestruct}
+    dynamic_gas = new_account_gas + cold_account_access_gas
+    
+    new_account_gas = {gasPrices|callNewAccount} if a positive balance is sent to an empty account
+    cold_account_access_gas = {gasPrices|coldaccountaccess} if `address` is cold
+
+
+See section [access sets](/about).
 
 ## Gas refunds
 

--- a/docs/opcodes/FF/london.mdx
+++ b/docs/opcodes/FF/london.mdx
@@ -1,3 +1,10 @@
 ## Gas
 
-The static gas is {gasPrices|selfdestruct}. If a positive balance is sent to an empty account, the dynamic gas is {gasPrices|callNewAccount}. An account is empty if its balance is 0, its nonce is 0 and it has no code. Additionally, if `address` is cold, there is an additional dynamic cost of {gasPrices|coldaccountaccess}. See section [access sets](/about). There is no additional cost otherwise.
+    gas_cost = static_gas + dynamic_gas
+    static_gas = {gasPrices|selfdestruct}
+    dynamic_gas = new_account_gas + cold_account_access_gas
+
+    new_account_gas = {gasPrices|callNewAccount} if a positive balance is sent to an empty account
+    cold_account_access_gas = {gasPrices|coldaccountaccess} if `address` is cold
+
+An account is empty if its balance is 0, its nonce is 0 and it has no code. See section [access sets](/about).

--- a/docs/opcodes/FF/spuriousDragon.mdx
+++ b/docs/opcodes/FF/spuriousDragon.mdx
@@ -1,6 +1,10 @@
 ## Gas
 
-The static gas is {gasPrices|selfdestruct}. If a positive balance is sent to an empty account, the dynamic gas is {gasPrices|callNewAccount}. Otherwise there is no additional cost. An account is empty if its balance is 0, its nonce is 0 and it has no code.
+    gas_cost = static_gas + dynamic_gas
+    static_gas = {gasPrices|selfdestruct}
+    dynamic_gas = {gasPrices|callNewAccount} if a positive balance is sent to an empty account
+
+An account is empty if its balance is 0, its nonce is 0 and it has no code.
 
 ## Gas refunds
 

--- a/docs/opcodes/FF/tangerineWhistle.mdx
+++ b/docs/opcodes/FF/tangerineWhistle.mdx
@@ -1,6 +1,8 @@
 ## Gas
 
-The static gas is {gasPrices|selfdestruct}. If `address` is an unexisting account, the dynamic cost is {gasPrices|callNewAccount}. Otherwise there is no additional cost.
+    gas_cost = static_gas + dynamic_gas
+    static_gas = {gasPrices|selfdestruct}
+    dynamic_gas = {gasPrices|callNewAccount} if `address` is an unexisting account
 
 ## Gas refunds
 

--- a/docs/precompiled/0x02/homestead.mdx
+++ b/docs/precompiled/0x02/homestead.mdx
@@ -2,5 +2,6 @@
 
     data_word_size = (data_size + 31) / 32
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|sha256}
     dynamic_gas = {gasPrices|sha256Word} * data_word_size

--- a/docs/precompiled/0x03/homestead.mdx
+++ b/docs/precompiled/0x03/homestead.mdx
@@ -2,5 +2,6 @@
 
     data_word_size = (data_size + 31) / 32
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|ripemd160}
     dynamic_gas = {gasPrices|ripemd160Word} * data_word_size

--- a/docs/precompiled/0x04/homestead.mdx
+++ b/docs/precompiled/0x04/homestead.mdx
@@ -2,5 +2,6 @@
 
     data_word_size = (data_size + 31) / 32
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = {gasPrices|identity}
     dynamic_gas = {gasPrices|identityWord} * data_word_size

--- a/docs/precompiled/0x05/berlin.mdx
+++ b/docs/precompiled/0x05/berlin.mdx
@@ -10,5 +10,6 @@
     elif Esize > 32: iteration_count = (8 * (Esize - 32)) + ((exponent & (2**256 - 1)).bit_length() - 1)
     calculate_iteration_count = max(iteration_count, 1)
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = 0
     dynamic_gas = max(200, multiplication_complexity * iteration_count / {gasPrices|modexpGquaddivisor})

--- a/docs/precompiled/0x05/byzantium.mdx
+++ b/docs/precompiled/0x05/byzantium.mdx
@@ -12,5 +12,6 @@
     elif Esize > 32: iteration_count = (8 * (Esize - 32)) + ((exponent & (2**256 - 1)).bit_length() - 1)
     calculate_iteration_count = max(iteration_count, 1)
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = 0
     dynamic_gas = max(200, multiplication_complexity * iteration_count / {gasPrices|modexpGquaddivisor})

--- a/docs/precompiled/0x06/byzantium.mdx
+++ b/docs/precompiled/0x06/byzantium.mdx
@@ -1,3 +1,5 @@
 ## Gas
 
-The gas cost is fixed at {gasPrices|ecAdd}. However, if the input does not allow to compute a valid result, all the gas sent is consumed.
+    gas_cost = {gasPrices|ecAdd}
+
+However, if the input does not allow to compute a valid result, all the gas sent is consumed.

--- a/docs/precompiled/0x07/byzantium.mdx
+++ b/docs/precompiled/0x07/byzantium.mdx
@@ -1,3 +1,5 @@
 ## Gas
 
-The gas cost is fixed at {gasPrices|ecMul}. However, if the input does not allow to compute a valid result, all the gas sent is consumed.
+    gas_cost = {gasPrices|ecAdd}
+
+However, if the input does not allow to compute a valid result, all the gas sent is consumed.

--- a/docs/precompiled/0x09/istanbul.mdx
+++ b/docs/precompiled/0x09/istanbul.mdx
@@ -1,5 +1,6 @@
 ## Gas
 
+    gas_cost = static_gas + dynamic_gas
     static_gas = 0
     dynamic_gas = rounds * {gasPrices|blake2Round}
 


### PR DESCRIPTION
I opened a first PR (#248) thinking that the gas computation for `log` opcodes was wrong. It turns out I was wrong but, as a newbie in this field, I find that the gas calculation is not 100% clear and could perhaps be improved? At the moment, the gas calculation mentions a static gas and a dynamic gas cost, but there's no formula linking the two (even if it's trivial, I can hear it). That's why I suggest adding the following formula: `gas_cost = static_gas + dynamic_gas` at the top of gas computations, to make it a bit clearer.

<img width="455" alt="Screenshot 2023-06-16 at 16 05 28" src="https://github.com/smlxl/evm.codes/assets/28714795/2ec86faf-5ee9-4cc8-a293-3db7b7179570">


On top of that, I transformed some of the text into formulas. I think that it ensures consistency between the different ways of calculating gas. One thing I'm not 100% sure though is how to deal with multi-line formulas such as the one used for the `balance` opcode in the `Berlin` hard fork.

This is how it renders:

<img width="278" alt="Screenshot 2023-06-16 at 16 06 24" src="https://github.com/smlxl/evm.codes/assets/28714795/334c51d6-d82d-4f0b-8411-0de9cf5e3502">

Another option may be the following:

<img width="280" alt="Screenshot 2023-06-16 at 16 20 06" src="https://github.com/smlxl/evm.codes/assets/28714795/14fa9070-56bd-4caa-be72-4bb1605824a5">
