### PR TITLE
fix: `staticcall` opcode was introduced during the `Byzantium` hard fork

### DIFF
--- a/docs/opcodes/FA.mdx
+++ b/docs/opcodes/FA.mdx
@@ -1,5 +1,5 @@
 ---
-fork: Homestead
+fork: Byzantium
 group: System operations
 ---
 


### PR DESCRIPTION
For reference: https://blog.ethereum.org/2017/10/12/byzantium-hf-announcement

- https://github.com/ethereum/execution-specs/blob/master/src/ethereum/byzantium/vm/instructions/system.py#L473
- https://github.com/ethereum/execution-specs/blob/master/src/ethereum/spurious_dragon/vm/instructions/system.py#L594