### PR TITLE
Add evm storage banner

### DIFF
--- a/components/EvmStorageBanner.tsx
+++ b/components/EvmStorageBanner.tsx
@@ -1,24 +1,24 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect } from 'react';
 
 const EvmStorageBanner = () => {
-  const [isShown, setIsShown] = useState(false)
+  const [isShown, setIsShown] = useState(false);
 
   useEffect(() => {
     // Check if the banner was closed previously
-    const isBannerClosed = localStorage.getItem('isBannerClosed')
+    const isBannerClosed = localStorage.getItem('isBannerClosed');
     if (!isBannerClosed) {
-      setIsShown(true)
+      setIsShown(true);
     }
-  }, [])
+  }, []);
 
   const handleCloseBanner = () => {
     // Save the state in local storage to prevent the banner from showing again
-    localStorage.setItem('isBannerClosed', 'true')
-    setIsShown(false)
-  }
+    localStorage.setItem('isBannerClosed', 'true');
+    setIsShown(false);
+  };
 
   if (!isShown) {
-    return null
+    return null;
   }
 
   return (
@@ -35,39 +35,25 @@ const EvmStorageBanner = () => {
           viewBox="0 0 24 24"
           stroke="currentColor"
         >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M6 18L18 6M6 6l12 12"
-          />
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
         </svg>
       </button>
       <div className="container mx-auto px-4 md:px-6">
-        <p className="font-medium md:text-xl mb-4 pt-6">
-          Introducing evm.storage
-        </p>
+        <p className="font-medium md:text-xl mb-4 pt-6">Introducing evm.storage</p>
         <p className="font-normal text-2base text-gray-400 mb-4">
-          Dive deep into the storage of any contract on Ethereum and Avalanche.
-          Explore contract storage and state at any block height.
+          Dive deep into the storage of any contract on Ethereum or Avalanche. Explore contract storage and state at any block height.
         </p>
         <div className="flex flex-row space-x-4 text-2base font-medium">
-          <a
-            className="underline text-indigo-500"
-            href="https://www.evm.storage"
-          >
+          <a className="underline text-indigo-500" href="https://www.evm.storage">
             Try it out
           </a>
-          <a
-            className="underline text-indigo-500"
-            href="https://blog.smlxl.io/introducing-evm-storage-c9fae8055286"
-          >
+          <a className="underline text-indigo-500" href="https://blog.smlxl.io/introducing-evm-storage-c9fae8055286">
             Learn more
           </a>
         </div>
       </div>
     </div>
-  )
-}
+  );
+};
 
-export default EvmStorageBanner
+export default EvmStorageBanner;

--- a/components/EvmStorageBanner.tsx
+++ b/components/EvmStorageBanner.tsx
@@ -1,60 +1,72 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 const EvmStorageBanner = () => {
-  const [isShown, setIsShown] = useState(true)
+  const [isShown, setIsShown] = useState(false)
+
+  useEffect(() => {
+    // Check if the banner was closed previously
+    const isBannerClosed = localStorage.getItem('isBannerClosed')
+    if (!isBannerClosed) {
+      setIsShown(true)
+    }
+  }, [])
+
+  const handleCloseBanner = () => {
+    // Save the state in local storage to prevent the banner from showing again
+    localStorage.setItem('isBannerClosed', 'true')
+    setIsShown(false)
+  }
 
   if (!isShown) {
     return null
   }
 
   return (
-    isShown && (
-      <div className={`relative bg-gray-50 dark:bg-black-700 pb-6 mt-0 mb-10`}>
-        <button
-          className="absolute top-6 right-6 focus:outline-none"
-          onClick={() => setIsShown(false)}
-          aria-label="Close banner"
+    <div className="relative bg-gray-50 dark:bg-black-700 pb-6 mt-0 mb-10">
+      <button
+        className="absolute top-6 right-6 focus:outline-none"
+        onClick={handleCloseBanner}
+        aria-label="Close banner"
+      >
+        <svg
+          className="h-6 w-6"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
         >
-          <svg
-            className="h-6 w-6"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M6 18L18 6M6 6l12 12"
+          />
+        </svg>
+      </button>
+      <div className="container mx-auto px-4 md:px-6">
+        <p className="font-medium md:text-xl mb-4 pt-6">
+          Introducing evm.storage
+        </p>
+        <p className="font-normal text-2base text-gray-400 mb-4">
+          Dive deep into the storage of any contract on Ethereum and Avalanche.
+          Explore contract storage and state at any block height.
+        </p>
+        <div className="flex flex-row space-x-4 text-2base font-medium">
+          <a
+            className="underline text-indigo-500"
+            href="https://www.evm.storage"
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-        </button>
-        <div className="container mx-auto px-4 md:px-6">
-          <p className="font-medium md:text-xl mb-4 pt-6">
-            Introducing evm.storage
-          </p>
-          <p className="font-normal text-2base text-gray-400 mb-4">
-            Dive deep into the storage of any contract on Ethereum and
-            Avalanche. Explore contract storage and state at any block height.
-          </p>
-          <div className="flex flex-row space-x-4 text-2base font-medium">
-            <a
-              className="underline text-indigo-500"
-              href="https://www.evm.storage"
-            >
-              Try it out
-            </a>
-            <a
-              className="underline text-indigo-500"
-              href="https://blog.smlxl.io/introducing-evm-storage-c9fae8055286"
-            >
-              Learn more
-            </a>
-          </div>
+            Try it out
+          </a>
+          <a
+            className="underline text-indigo-500"
+            href="https://blog.smlxl.io/introducing-evm-storage-c9fae8055286"
+          >
+            Learn more
+          </a>
         </div>
       </div>
-    )
+    </div>
   )
 }
 

--- a/components/EvmStorageBanner.tsx
+++ b/components/EvmStorageBanner.tsx
@@ -1,11 +1,15 @@
 import { useState } from 'react';
 
-const EvmStorageBanner = ({ className = "" }) => {
+const EvmStorageBanner = () => {
   const [isShown, setIsShown] = useState(true);
+
+  if (!isShown) {
+    return null; 
+  }
 
   return (
     isShown && (
-      <div className={`relative bg-gray-50 dark:bg-black-700 pb-6 ${className}`}>
+      <div className={`relative bg-gray-50 dark:bg-black-700 pb-6 mt-0 mb-10`}>
         <button
           className="absolute top-6 right-6 focus:outline-none"
           onClick={() => setIsShown(false)}

--- a/components/EvmStorageBanner.tsx
+++ b/components/EvmStorageBanner.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+const EvmStorageBanner = ({ className = "" }) => {
+  const [isShown, setIsShown] = useState(true);
+
+  return (
+    isShown && (
+      <div className={`relative bg-gray-50 dark:bg-black-700 pb-6 ${className}`}>
+        <button
+          className="absolute top-6 right-6 focus:outline-none"
+          onClick={() => setIsShown(false)}
+          aria-label="Close banner"
+        >
+          <svg className="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+        <div className="container mx-auto px-4 md:px-6">
+          <p className="font-medium md:text-xl mb-4 pt-6">Introducing evm.storage</p>
+          <p className="font-normal text-2base text-gray-400 mb-4">Dive deep into the storage of any contract on Ethereum and Avalanche. Explore contract storage and state at any block height.</p>
+          <div className="flex flex-row space-x-4 text-2base font-medium">
+            <a className="underline text-indigo-500" href="https://www.evm.storage">Try it out</a>
+            <a className="underline text-indigo-500" href="https://blog.smlxl.io/introducing-evm-storage-c9fae8055286">Learn more</a>
+          </div>
+        </div>
+      </div>
+    )
+  );
+};
+
+export default EvmStorageBanner;

--- a/components/EvmStorageBanner.tsx
+++ b/components/EvmStorageBanner.tsx
@@ -1,24 +1,24 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react'
 
 const EvmStorageBanner = () => {
-  const [isShown, setIsShown] = useState(false);
+  const [isShown, setIsShown] = useState(false)
 
   useEffect(() => {
     // Check if the banner was closed previously
-    const isBannerClosed = localStorage.getItem('isBannerClosed');
+    const isBannerClosed = localStorage.getItem('isBannerClosed')
     if (!isBannerClosed) {
-      setIsShown(true);
+      setIsShown(true)
     }
-  }, []);
+  }, [])
 
   const handleCloseBanner = () => {
     // Save the state in local storage to prevent the banner from showing again
-    localStorage.setItem('isBannerClosed', 'true');
-    setIsShown(false);
-  };
+    localStorage.setItem('isBannerClosed', 'true')
+    setIsShown(false)
+  }
 
   if (!isShown) {
-    return null;
+    return null
   }
 
   return (
@@ -35,25 +35,39 @@ const EvmStorageBanner = () => {
           viewBox="0 0 24 24"
           stroke="currentColor"
         >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M6 18L18 6M6 6l12 12"
+          />
         </svg>
       </button>
       <div className="container mx-auto px-4 md:px-6">
-        <p className="font-medium md:text-xl mb-4 pt-6">Introducing evm.storage</p>
+        <p className="font-medium md:text-xl mb-4 pt-6">
+          Introducing evm.storage
+        </p>
         <p className="font-normal text-2base text-gray-400 mb-4">
-          Dive deep into the storage of any contract on Ethereum or Avalanche. Explore contract storage and state at any block height.
+          Dive deep into the storage of any contract on Ethereum or Avalanche.
+          Explore contract storage and state at any block height.
         </p>
         <div className="flex flex-row space-x-4 text-2base font-medium">
-          <a className="underline text-indigo-500" href="https://www.evm.storage">
+          <a
+            className="underline text-indigo-500"
+            href="https://www.evm.storage"
+          >
             Try it out
           </a>
-          <a className="underline text-indigo-500" href="https://blog.smlxl.io/introducing-evm-storage-c9fae8055286">
+          <a
+            className="underline text-indigo-500"
+            href="https://blog.smlxl.io/introducing-evm-storage-c9fae8055286"
+          >
             Learn more
           </a>
         </div>
       </div>
     </div>
-  );
-};
+  )
+}
 
-export default EvmStorageBanner;
+export default EvmStorageBanner

--- a/components/EvmStorageBanner.tsx
+++ b/components/EvmStorageBanner.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
+import { useState } from 'react'
 
 const EvmStorageBanner = () => {
-  const [isShown, setIsShown] = useState(true);
+  const [isShown, setIsShown] = useState(true)
 
   if (!isShown) {
-    return null; 
+    return null
   }
 
   return (
@@ -15,21 +15,47 @@ const EvmStorageBanner = () => {
           onClick={() => setIsShown(false)}
           aria-label="Close banner"
         >
-          <svg className="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          <svg
+            className="h-6 w-6"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
           </svg>
         </button>
         <div className="container mx-auto px-4 md:px-6">
-          <p className="font-medium md:text-xl mb-4 pt-6">Introducing evm.storage</p>
-          <p className="font-normal text-2base text-gray-400 mb-4">Dive deep into the storage of any contract on Ethereum and Avalanche. Explore contract storage and state at any block height.</p>
+          <p className="font-medium md:text-xl mb-4 pt-6">
+            Introducing evm.storage
+          </p>
+          <p className="font-normal text-2base text-gray-400 mb-4">
+            Dive deep into the storage of any contract on Ethereum and
+            Avalanche. Explore contract storage and state at any block height.
+          </p>
           <div className="flex flex-row space-x-4 text-2base font-medium">
-            <a className="underline text-indigo-500" href="https://www.evm.storage">Try it out</a>
-            <a className="underline text-indigo-500" href="https://blog.smlxl.io/introducing-evm-storage-c9fae8055286">Learn more</a>
+            <a
+              className="underline text-indigo-500"
+              href="https://www.evm.storage"
+            >
+              Try it out
+            </a>
+            <a
+              className="underline text-indigo-500"
+              href="https://blog.smlxl.io/introducing-evm-storage-c9fae8055286"
+            >
+              Learn more
+            </a>
           </div>
         </div>
       </div>
     )
-  );
-};
+  )
+}
 
-export default EvmStorageBanner;
+export default EvmStorageBanner

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -16,6 +16,7 @@ import ContributeBox from 'components/ContributeBox'
 import HomeLayout from 'components/layouts/Home'
 import ReferenceTable from 'components/Reference'
 import { H1, Container } from 'components/ui'
+import EvmStorageBanner from 'components/EvmStorageBanner'
 
 const { serverRuntimeConfig } = getConfig()
 
@@ -38,6 +39,7 @@ const HomePage = ({
           content="An Ethereum Virtual Machine Opcodes Interactive Reference"
         />
       </Head>
+      <EvmStorageBanner className="mt-0 mb-10" />
       <Container>
         <H1>
           An Ethereum Virtual Machine <br></br> Opcodes Interactive Reference

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -39,7 +39,7 @@ const HomePage = ({
           content="An Ethereum Virtual Machine Opcodes Interactive Reference"
         />
       </Head>
-      <EvmStorageBanner className="mt-0 mb-10" />
+      <EvmStorageBanner/>
       <Container>
         <H1>
           An Ethereum Virtual Machine <br></br> Opcodes Interactive Reference

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,10 +13,10 @@ import { IItemDocs, IGasDocs, IDocMeta } from 'types'
 import { EthereumContext } from 'context/ethereumContext'
 
 import ContributeBox from 'components/ContributeBox'
+import EvmStorageBanner from 'components/EvmStorageBanner'
 import HomeLayout from 'components/layouts/Home'
 import ReferenceTable from 'components/Reference'
 import { H1, Container } from 'components/ui'
-import EvmStorageBanner from 'components/EvmStorageBanner'
 
 const { serverRuntimeConfig } = getConfig()
 
@@ -39,7 +39,7 @@ const HomePage = ({
           content="An Ethereum Virtual Machine Opcodes Interactive Reference"
         />
       </Head>
-      <EvmStorageBanner/>
+      <EvmStorageBanner />
       <Container>
         <H1>
           An Ethereum Virtual Machine <br></br> Opcodes Interactive Reference


### PR DESCRIPTION
I added an evm.storage banner. It can be closed, but it will reopen when the user refreshes the page. My thought is that we would only use this banner for a few weeks and then we could explore a more permanent place to add the link.

Tried to do this in a way that was clean and aligned with @alannafischer's designs. May not be quite pixel perfect but should be very close.

[will fix the prettier stuff now]