### PR TITLE
Enhance invalid input description for precompiles

### DIFF
--- a/docs/precompiled/0x01.mdx
+++ b/docs/precompiled/0x01.mdx
@@ -21,7 +21,7 @@ More information about ECDSA can be found [here](https://en.wikipedia.org/wiki/E
 |-----------:|-----:|------------:|
 | [0; 31] (32 bytes) | publicAddress | The recovered 20-byte address right aligned to 32 bytes |
 
-If an address cannot be recovered, or not enough gas was given, then there is no return data. Please note, that the return data is the address that issued the signature but it won't verify the signature.
+If an address cannot be recovered or not enough gas was given, then there is no return data, indicating a precompile contract error. Please note, that the return data is the address that issued the signature but it won't verify the signature.
 
 ## Example
 

--- a/docs/precompiled/0x02.mdx
+++ b/docs/precompiled/0x02.mdx
@@ -14,7 +14,7 @@ fork: Frontier
 |-----------:|-----:|------------:|
 | [0; 31] (32 bytes) | hash | The result hash |
 
- If not enough gas was given, then there is no return data.
+ If not enough gas was given, then there is no return data, indicating a precompile contract error.
 
 ## Example
 

--- a/docs/precompiled/0x03.mdx
+++ b/docs/precompiled/0x03.mdx
@@ -14,7 +14,7 @@ fork: Frontier
 |-----------:|-----:|------------:|
 | [0; 31] (32 bytes) | hash | The result 20-byte hash right aligned to 32 bytes |
 
- If not enough gas was given, then there is no return data.
+ If not enough gas was given, then there is no return data, indicating a precompile contract error.
 
 ## Example
 

--- a/docs/precompiled/0x04.mdx
+++ b/docs/precompiled/0x04.mdx
@@ -18,7 +18,7 @@ The identity function is typically used to copy a chunk of memory.
 |-----------:|-----:|------------:|
 | `[0; length[` | data | Data from input |
 
- If not enough gas was given, then there is no return data.
+ If not enough gas was given, then there is no return data, indicating a precompile contract error.
 
 ## Example
 

--- a/docs/precompiled/0x05.mdx
+++ b/docs/precompiled/0x05.mdx
@@ -19,7 +19,7 @@ fork: Byzantium
 |-----------:|-----:|------------:|
 | `[0; mSize[` | value | Result of the computation, with the same number of bytes as M |
 
- If not enough gas was given, then there is no return data.
+ If not enough gas was given, then there is no return data, indicating a precompile contract error.
 
 ## Example
 

--- a/docs/precompiled/0x06.mdx
+++ b/docs/precompiled/0x06.mdx
@@ -22,7 +22,7 @@ The point at infinity is encoded with both field `x` and `y` at `0`.
 | `[0; 31]` (32 bytes) | x | X coordinate of the result point on the elliptic curve 'alt_bn128' |
 | `[32; 63]` (32 bytes) | y | Y coordinate of the result point on the elliptic curve 'alt_bn128' |
 
-If the input is not valid, or if not enough gas was given, then there is no return data.
+If the input is not valid, all gas provided is consumed and there is no return data, indicating a precompile contract error. Also, if not enough gas was given, there is no return data.
 
 ## Example
 

--- a/docs/precompiled/0x07.mdx
+++ b/docs/precompiled/0x07.mdx
@@ -21,7 +21,7 @@ The point at infinity is encoded with both field `x` and `y` at `0`.
 | `[0; 31]` (32 bytes) | x | X coordinate of the result point on the elliptic curve 'alt_bn128' |
 | `[32; 63]` (32 bytes) | y | Y coordinate of the result point on the elliptic curve 'alt_bn128' |
 
-If the input is not valid, or if not enough gas was given, then there is no return data.
+If the input is not valid, all gas provided is consumed and there is no return data, indicating a precompile contract error. Also, if not enough gas was given, there is no return data.
 
 ## Example
 

--- a/docs/precompiled/0x08.mdx
+++ b/docs/precompiled/0x08.mdx
@@ -25,7 +25,7 @@ The input must always be a multiple of 6 32-byte values. 0 inputs is valid and r
 |-----------:|-----:|------------:|
 | `[0; 31]` (32 bytes) | success | 1 if the pairing was a success, 0 otherwise |
 
-If the input is not valid, or if not enough gas was given, then there is no return data.
+If the input is not valid, all gas provided is consumed and there is no return data, indicating a precompile contract error. Also, if not enough gas was given, there is no return data.
 
 ## Example
 

--- a/docs/precompiled/0x09.mdx
+++ b/docs/precompiled/0x09.mdx
@@ -18,7 +18,7 @@ fork: Istanbul
 |-----------:|-----:|------------:|
 | `[0; 63]` (64 bytes) | h | State vector (8 8-byte little-endian unsigned integer) |
 
-If the input is not valid, or if not enough gas was given, then there is no return data.
+If the input is not valid, all gas provided is consumed and there is no return data, indicating a precompile contract error. Also, if not enough gas was given, there is no return data.
 
 ## Example
 


### PR DESCRIPTION
Fixes https://github.com/smlxl/evm.codes/issues/259. In order to verify this behaviour, you can look at the [`py-evm`](https://github.com/ethereum/py-evm/tree/master/eth/precompiles) implementations.