### PR TITLE
add shanghai to post-merge HF list

### DIFF
--- a/components/Reference/index.tsx
+++ b/components/Reference/index.tsx
@@ -18,7 +18,7 @@ import { IReferenceItem, IItemDocs, IGasDocs } from 'types'
 
 import {
   EthereumContext,
-  mergeHardforkName,
+  postMergeHardforkNames,
   prevrandaoDocName,
 } from 'context/ethereumContext'
 
@@ -82,7 +82,9 @@ const ReferenceTable = ({
     (opcodeOrAddress: string) => {
       // @ts-ignore: TODO: need to implement proper selection of doc according to selected fork (maybe similar to dynamic gas fee)
       // @ts-ignore: Hack for "difficulty" -> "prevrandao" replacement for "merge" HF
-      return opcodeOrAddress == '44' && selectedFork?.name === mergeHardforkName
+      return opcodeOrAddress == '44' &&
+        selectedFork?.name != null &&
+        postMergeHardforkNames.indexOf(selectedFork?.name) > -1
         ? itemDocs[prevrandaoDocName]
         : itemDocs[opcodeOrAddress]
     },

--- a/components/Reference/index.tsx
+++ b/components/Reference/index.tsx
@@ -18,7 +18,7 @@ import { IReferenceItem, IItemDocs, IGasDocs } from 'types'
 
 import {
   EthereumContext,
-  postMergeHardforkNames,
+  CheckIfAfterMergeHardfork,
   prevrandaoDocName,
 } from 'context/ethereumContext'
 
@@ -83,8 +83,7 @@ const ReferenceTable = ({
       // @ts-ignore: TODO: need to implement proper selection of doc according to selected fork (maybe similar to dynamic gas fee)
       // @ts-ignore: Hack for "difficulty" -> "prevrandao" replacement for "merge" HF
       return opcodeOrAddress == '44' &&
-        selectedFork?.name != null &&
-        postMergeHardforkNames.indexOf(selectedFork?.name) > -1
+        CheckIfAfterMergeHardfork(selectedFork?.name)
         ? itemDocs[prevrandaoDocName]
         : itemDocs[opcodeOrAddress]
     },

--- a/context/ethereumContext.tsx
+++ b/context/ethereumContext.tsx
@@ -43,7 +43,7 @@ const accountBalance = 18 // 1eth
 const accountAddress = Address.fromPrivateKey(privateKey)
 const contractAddress = Address.generate(accountAddress, 1n)
 const gasLimit = 0xffffffffffffn
-export const postMergeHardforkNames: Array<string> = ['merge', 'shanghai']
+const postMergeHardforkNames: Array<string> = ['merge', 'shanghai']
 export const prevrandaoDocName = '44_merge'
 
 type ContextProps = {
@@ -120,6 +120,13 @@ export const EthereumContext = createContext<ContextProps>({
   nextExecution: () => undefined,
   resetExecution: () => undefined,
 })
+
+export const CheckIfAfterMergeHardfork = (forkName?: string) => {
+  if (forkName == null) {
+    return false
+  }
+  return postMergeHardforkNames.indexOf(forkName) > -1
+}
 
 export const EthereumProvider: React.FC<{}> = ({ children }) => {
   const [chains, setChains] = useState<IChain[]>([])
@@ -454,8 +461,7 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
     // TODO: need to implement proper selection of doc according to selected fork (maybe similar to dynamic gas fee)
     // Hack for "difficulty" -> "prevrandao" replacement for "merge" HF
     if (
-      selectedFork?.name != null &&
-      postMergeHardforkNames.indexOf(selectedFork?.name) > -1 &&
+      CheckIfAfterMergeHardfork(selectedFork?.name) &&
       toHex(op.code) == '44'
     ) {
       return {

--- a/context/ethereumContext.tsx
+++ b/context/ethereumContext.tsx
@@ -43,7 +43,7 @@ const accountBalance = 18 // 1eth
 const accountAddress = Address.fromPrivateKey(privateKey)
 const contractAddress = Address.generate(accountAddress, 1n)
 const gasLimit = 0xffffffffffffn
-export const mergeHardforkName = 'merge'
+export const postMergeHardforkNames: Array<string> = ['merge', 'shanghai']
 export const prevrandaoDocName = '44_merge'
 
 type ContextProps = {
@@ -453,7 +453,11 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
     const meta = OpcodesMeta as IReferenceItemMetaList
     // TODO: need to implement proper selection of doc according to selected fork (maybe similar to dynamic gas fee)
     // Hack for "difficulty" -> "prevrandao" replacement for "merge" HF
-    if (selectedFork?.name === mergeHardforkName && toHex(op.code) == '44') {
+    if (
+      selectedFork?.name != null &&
+      postMergeHardforkNames.indexOf(selectedFork?.name) > -1 &&
+      toHex(op.code) == '44'
+    ) {
       return {
         ...meta[prevrandaoDocName],
         ...{


### PR DESCRIPTION
##### Description
- We add `shanghai` to the post merge HF list.
- When checking if the user selected the `merge` HF, we now check against the list.

This addresses [this issue](https://github.com/smlxl/evm.codes/issues/263).<br>
Note: This is still a hacky workaround, we should consider the refactoring suggested in the `TODO` comments.

##### Tested

Locally with `yarn dev`