### PR TITLE
chore: Clean up chain ids

### DIFF
--- a/docs/opcodes/46.mdx
+++ b/docs/opcodes/46.mdx
@@ -7,20 +7,14 @@ group: Block Information
 
 ## Notes
 
-Here are some chain ids ([source](https://besu.hyperledger.org/en/stable/Concepts/NetworkID-And-ChainID/)):
+Here are some chain ids:
 
 | Id | Chain |
 |---:|------:|
 | 1 | Mainnet |
-| 3 | Ropsten |
-| 4 | Rinkeby |
 | 5 | Goerli |
-| 6 | Kotti |
-| 61 | Classic |
-| 63 | Mordor |
-| 212 | Astor |
-| 2018 | Dev |
 | 11155111 | Sepolia |
+| 17000 | Holešky |
 
 ## Stack output
 


### PR DESCRIPTION
This PR deletes a broken link, removes deprecated testnets, and adds the chain ID for the new [Holešky testnet](https://github.com/eth-clients/holesky).