### PR TITLE
update-evm-storage-banner

### DIFF
--- a/components/EvmStorageBanner.tsx
+++ b/components/EvmStorageBanner.tsx
@@ -48,23 +48,17 @@ const EvmStorageBanner = () => {
           Introducing evm.storage
         </p>
         <p className="font-normal text-2base text-gray-400 mb-4">
-          Dive deep into the storage of any contract on Ethereum or Avalanche.
-          Explore contract storage and state at any block height.
-        </p>
-        <div className="flex flex-row space-x-4 text-2base font-medium">
+          Explore any contract, externally owned account, or transaction on
+          Ethereum and Avalanche. With contract interaction, an unrivaled
+          representation of storage, and transaction tracing and simulation,
+          evm.storage is the blockchain explorer designed for you.{' '}
           <a
             className="underline text-indigo-500"
             href="https://www.evm.storage"
           >
             Try it out
           </a>
-          <a
-            className="underline text-indigo-500"
-            href="https://blog.smlxl.io/introducing-evm-storage-c9fae8055286"
-          >
-            Learn more
-          </a>
-        </div>
+        </p>
       </div>
     </div>
   )


### PR DESCRIPTION
Updates copy of the EVM Storage banner to reference new features. Removes the link to the original launch blog from June, given that blog is no longer representative of the current state of the product. Takes the remaining "Try it out" link and moves it in-line just to reduce the footprint of the banner a little now that we only have one link.

**To test**: Compare [prod](https://evm.codes) to [preview](https://evm-codes-git-12-05-update-evm-storage-banner-smlxl.vercel.app/?fork=shanghai).

Resolves SML-4297