### PR TITLE
Allow 0x prefix in bytecode editor

### DIFF
--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -285,11 +285,13 @@ const Editor = ({ readOnly = false }: Props) => {
   }
 
   const stripBytecode = (value: string) => {
+    const findHexPrefix = /^0x/
     return value
       .replaceAll(/\/\/.*$/gm, '')
       .replaceAll(/;.*$/gm, '')
       .replaceAll(/#.*$/gm, '')
       .replaceAll(/\s/gm, '')
+      .replace(findHexPrefix, '')
   }
 
   const handleCodeChange = (value: string) => {


### PR DESCRIPTION
Fixes #280 

Allow bytecode to include the `0x` prefix without it being considered illegal opcode. 

## Test plan
- Open playground https://evm-codes-git-feature-allow-0x-prefix-with-bytecode-smlxl.vercel.app/playground
    - Add a `0x` prefix i.e `0x604260005260206000F3` and it should not load with a `INVALID` opcode like it currently does with main
    - ![Screenshot 2023-12-12 at 09 27 36](https://github.com/smlxl/evm.codes/assets/5640782/a336df78-5a72-4361-8cf3-68809fb83504)

