### PR TITLE
fix: add changes from eip3860

### DIFF
--- a/docs/opcodes/F0.mdx
+++ b/docs/opcodes/F0.mdx
@@ -45,3 +45,4 @@ The state changes done by the current context are [reverted](#FD) in those cases
 - Not enough gas.
 - Not enough values on the stack.
 - The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork).
+- `size` is greater than the chain's maximum initcode size (since Shanghai fork).

--- a/docs/opcodes/F0/shanghai.mdx
+++ b/docs/opcodes/F0/shanghai.mdx
@@ -1,0 +1,14 @@
+## Gas
+
+    minimum_word_size = (size + 31) / 32
+    init_code_cost = {gasPrices|initCodeWordCost} * minimum_word_size
+    code_deposit_cost = {gasPrices|createData} * deployed_code_size
+
+    static_gas = {gasPrices|create}
+    dynamic_gas = init_code_cost + memory_expansion_cost + deployment_code_execution_cost + code_deposit_cost
+
+The `deployment_code_execution_cost` is the cost of whatever opcode is run to deploy the new contract.
+On top of that, there are additional costs for storing the code of the new contract and performing a jumpdest-analysis, respectively shown as `code_deposit_cost` and `init_code_cost`.
+The memory expansion cost explanation can be found [here](/about).
+
+The new contract address is added in the warm addresses. See section [access sets](/about).

--- a/docs/opcodes/F5.mdx
+++ b/docs/opcodes/F5.mdx
@@ -46,3 +46,4 @@ The state changes done by the current context are [reverted](#FD) in those cases
 - Not enough gas.
 - Not enough values on the stack.
 - The current execution context is from a [STATICCALL](/#FA).
+- `size` is greater than the chain's maximum initcode size (since Shanghai fork).

--- a/docs/opcodes/F5/shanghai.mdx
+++ b/docs/opcodes/F5/shanghai.mdx
@@ -1,0 +1,16 @@
+## Gas
+
+    minimum_word_size = (size + 31) / 32
+    init_code_cost = {gasPrices|initCodeWordCost} * minimum_word_size
+    hash_cost = {gasPrices|sha3Word} * minimum_word_size
+    code_deposit_cost = {gasPrices|createData} * deployed_code_size
+
+    static_gas = {gasPrices|create}
+    dynamic_gas = init_code_cost + hash_cost + memory_expansion_cost + deployment_code_execution_cost + code_deposit_cost
+
+The `deployment_code_execution_cost` is the cost of whatever opcode is run to deploy the new contract.
+On top of that, there are additional costs for storing the code of the new contract and performing a jumpdest-analysis, respectively shown as `code_deposit_cost` and `init_code_cost`.
+The difference with [CREATE](#F0) is an additional cost to hash the initialisation code before.
+The memory expansion cost explanation can be found [here](/about).
+
+The new contract address is added in the warm addresses. See section [access sets](/about).

--- a/util/gas.ts
+++ b/util/gas.ts
@@ -120,7 +120,21 @@ function createCost(common: Common, inputs: any): BN {
   const depositCost = new BN(inputs.deployedSize).imuln(
     Number(common.param('gasPrices', 'createData')),
   )
-  return expansionCost.iadd(depositCost).iadd(new BN(inputs.executionCost))
+
+  const result = expansionCost
+    .iadd(depositCost)
+    .iadd(new BN(inputs.executionCost))
+
+  if (common.gteHardfork('shanghai')) {
+    const initCodeCost = new BN(
+      toWordSize(new BN(inputs.size)).imuln(
+        Number(common.param('gasPrices', 'initCodeWordCost')),
+      ),
+    )
+    result.iadd(initCodeCost)
+  }
+
+  return result
 }
 
 function callCost(common: Common, inputs: any): BN {


### PR DESCRIPTION
The [EIP3860](https://eips.ethereum.org/EIPS/eip-3860) included in Shanghai hard fork led to changes in behaviour and gas consumption of the opcodes `CREATE` (`0xf0`) and `CREATE2` (`0xf5`). This PR reflect these changes in evm.codes.