### PR TITLE
fix: examples for create and create2

### DIFF
--- a/docs/opcodes/F0.mdx
+++ b/docs/opcodes/F0.mdx
@@ -36,7 +36,7 @@ Note that these failures only affect the return value and do not cause the calli
 
 ## Examples
 
-[See in playground](/playground?callValue=9&unit=Wei&codeType=Mnemonic&code='z0q0f9q9f0y4%20FFmslk3%200x63FFFFFFFF6000526004601CF3jvMSTORE~13jjp%20'~k%20z%2F%2F%20Createmnmccountgith%20ygeimnd%20v%5Cnqynoljj~pvCREATEm%20al%20codekvPUSH1j~0g%20wfpvvz%01fgjklmpqvyz~_).
+[See in playground](/playground?callValue=9&unit=Wei&codeType=Mnemonic&code='z0q0f9q9f0y4%20FFmslk3%200x63FFFFFFFF6000526004601CF3gvMSTORE~13~19gp%20'~k%20z%2F%2F%20Createmnmccountjith%20yjeimnd%20v%5Cnqynolgg~pvCREATEm%20al%20codekvPUSH1j%20wg~0fpvvz%01fgjklmpqvyz~_).
 
 ## Error cases
 

--- a/docs/opcodes/F5.mdx
+++ b/docs/opcodes/F5.mdx
@@ -38,7 +38,7 @@ Note that these failures only affect the return value and do not cause the calli
 
 ## Examples
 
-[See in playground](/playground?callValue=9&unit=Wei&codeType=Mnemonic&code='z0NLjannoXrecVQfparameters%2C%20becausliXgeneratesfaddressLz9N~1_~9Zyyz0v4%20FFYskW3%200x63FFFFFFFF60005260046000F3~0yMSTORE~2~13q'~W%20zjVanYccounXQ%20y%5Cnv%20weiYnd%20q_Zle%20k%20codej%2F%2F%20Cf%20thlsaml_~0~0ZyCREATE2Y%20aXt%20WyPUSH1VreatlQwithNvnokL_qyy%01LNQVWXYZ_fjklqvyz~_).
+[See in playground](/playground?callValue=9&unit=Wei&codeType=Mnemonic&code='z0LjjVfannoYrecWQ_parameters%2C%20becausliYgenerates_addressjjVz9L~1j~9Vz0v4%20FFZskX3%200x63FFFFFFFF60005260046000F3NyMSTORE~2~13~19Nq'~X%20zfWanZccounYQ%20y%5Cnv%20weiZnd%20qyCREATE2le%20k%20codejNNf%2F%2F%20C_%20thlsamlZ%20aYt%20XyPUSH1WreatlVqyyQwithN~0Lvnok%01LNQVWXYZ_fjklqvyz~_).
 
 ## Error cases
 


### PR DESCRIPTION

fix #185, the memory offset of the init code passed to `CREATE` and `CREATE2` would be incorrect, `0` instead of `19`. It can be easily verified by adding `EXTCODESIZE` at the end of the bytecode which would now return `4` when it previously returned `0`.