### PR TITLE
chore: upgrade prettier to v3

### DIFF
--- a/components/Editor/ExecutionState.tsx
+++ b/components/Editor/ExecutionState.tsx
@@ -18,8 +18,8 @@ const ExecutionStateRow = ({ label, value }: RowProps) => {
     !value || value.length === 0
       ? ['']
       : Array.isArray(value)
-      ? value
-      : ([value] as string[])
+        ? value
+        : ([value] as string[])
 
   return (
     <>

--- a/lib/solcWorker.js
+++ b/lib/solcWorker.js
@@ -181,13 +181,13 @@ onmessage = function (e) {
     }
   }
 
-  const contracts = [];
+  const contracts = []
 
   for (const contractName in output.contracts.web) {
     contracts.push({
       name: contractName,
       code: output.contracts.web[contractName].evm.bytecode.object,
-      abi: output.contracts.web[contractName].abi
+      abi: output.contracts.web[contractName].abi,
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev",
+    "format": "prettier --write \"**/*.{css,js,jsx,ts,tsx}\"",
     "lint": "eslint --ext js,jsx,ts,tsx .",
     "lint:package": "sort-package-json",
     "typecheck": "tsc --pretty"
@@ -69,7 +70,7 @@
     "husky": "^7.0.2",
     "loader-utils": "^2.0.4",
     "postcss": "^8.4.35",
-    "prettier": "^2.4.1",
+    "prettier": "^3.2.5",
     "sort-package-json": "^1.52.0",
     "swc-loader": "^0.2.6",
     "tailwindcss": "^3.4.1",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -130,7 +130,7 @@ html {
 
 .select__option {
   @apply text-sm py-2 px-3 font-normal text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white cursor-pointer hover:bg-gray-50 dark:hover:bg-black-500 !important;
-  @apply capitalize
+  @apply capitalize;
 }
 
 .select__option--is-selected {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "target": "ESNext",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "ESNext"
-    ],
+    "lib": ["dom", "dom.iterable", "ESNext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -20,12 +16,6 @@
     "jsx": "preserve",
     "incremental": true
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4892,10 +4892,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.4.1:
-  version "2.4.1"
-  resolved "https://package-cluster.production.groovehq.com/prettier/-/prettier-2.4.1.tgz"
-  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
+prettier@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.2.5.tgz#e52bc3090586e824964a8813b09aba6233b28368"
+  integrity sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==
 
 process@^0.11.10:
   version "0.11.10"


### PR DESCRIPTION
## Changes
- upgrade `prettier` from 2.4.1 to 3.2.5
- add `format` npm script to `package.json`
- run `yarn format` over full codebase