### PR TITLE
fix: keccak256 playground example

### DIFF
--- a/docs/opcodes/20.mdx
+++ b/docs/opcodes/20.mdx
@@ -25,7 +25,7 @@ group: SHA3
 | `1` | `0` | `0x29045A592007D0C246EF02C2223570DA9522D0CF0F73282C79A1BC8F0BB2C238` |
 | `2` | `4` | |
 
-[Reproduce in playground](/playground?unit=Wei&codeType=Mnemonic&code='sPutkrequired%20valugin%20memoryj32%200xFFFFFFFFffffz0wMSTOREwwsCallkopcodez4z0wSHA3'~0000000zj1%20w%5Cns%2F%2F%20k%20thgjwPUSHge%20f~~%01fgjkswz~_).
+[Reproduce in playground](/playground?unit=Wei&codeType=Mnemonic&code='sPutkrequired%20valugin%20memoryj32%200xFFFFFFFFffffz0wMSTOREwwsCallkopcodez4z0wKECCAK256'~0000000zj1%20w%5Cns%2F%2F%20k%20thgjwPUSHge%20f~~%01fgjkswz~_).
 
 ## Error cases
 


### PR DESCRIPTION
The existing playground example uses the SHA3 opcode, which the playground doesn't recognize.

The fix is to replace SHA3 with KECCAK256.

Related: #311