### PR TITLE
fix: replace sha3 with keccak256 in gas calculations

### DIFF
--- a/docs/opcodes/20/homestead.mdx
+++ b/docs/opcodes/20/homestead.mdx
@@ -2,7 +2,7 @@
 
     minimum_word_size = (size + 31) / 32
 
-    static_gas = {gasPrices|sha3}
-    dynamic_gas = {gasPrices|sha3Word} * minimum_word_size + memory_expansion_cost
+    static_gas = {gasPrices|keccak256}
+    dynamic_gas = {gasPrices|keccak256Word} * minimum_word_size + memory_expansion_cost
 
 The memory expansion cost explanation can be found [here](/about).

--- a/docs/opcodes/F5/berlin.mdx
+++ b/docs/opcodes/F5/berlin.mdx
@@ -4,7 +4,7 @@
     code_deposit_cost = {gasPrices|createData} * deployed_code_size
 
     static_gas = {gasPrices|create}
-    dynamic_gas = {gasPrices|sha3Word} * minimum_word_size + memory_expansion_cost + deployment_code_execution_cost + code_deposit_cost
+    dynamic_gas = {gasPrices|keccak256Word} * minimum_word_size + memory_expansion_cost + deployment_code_execution_cost + code_deposit_cost
 
 The `deployment_code_execution_cost` is the cost of whatever opcode is run to deploy the new contract.
 On top of that, there is an additional cost for storing the code of the new contract, shown as `code_deposit_cost`.

--- a/docs/opcodes/F5/constantinople.mdx
+++ b/docs/opcodes/F5/constantinople.mdx
@@ -4,7 +4,7 @@
     code_deposit_cost = {gasPrices|createData} * deployed_code_size
 
     static_gas = {gasPrices|create}
-    dynamic_gas = {gasPrices|sha3Word} * minimum_word_size + memory_expansion_cost + deployment_code_execution_cost + code_deposit_cost
+    dynamic_gas = {gasPrices|keccak256Word} * minimum_word_size + memory_expansion_cost + deployment_code_execution_cost + code_deposit_cost
 
 The `deployment_code_execution_cost` is the cost of whatever opcode is run to deploy the new contract.
 On top of that, there is an additional cost for storing the code of the new contract, shown as `code_deposit_cost`.

--- a/docs/opcodes/F5/shanghai.mdx
+++ b/docs/opcodes/F5/shanghai.mdx
@@ -2,7 +2,7 @@
 
     minimum_word_size = (size + 31) / 32
     init_code_cost = {gasPrices|initCodeWordCost} * minimum_word_size
-    hash_cost = {gasPrices|sha3Word} * minimum_word_size
+    hash_cost = {gasPrices|keccak256Word} * minimum_word_size
     code_deposit_cost = {gasPrices|createData} * deployed_code_size
 
     static_gas = {gasPrices|create}

--- a/util/gas.ts
+++ b/util/gas.ts
@@ -338,7 +338,7 @@ export const calculateOpcodeDynamicFee = (
       break
     }
     case '20': {
-      result = memoryCostCopy(inputs, 'sha3Word', common)
+      result = memoryCostCopy(inputs, 'keccak256Word', common)
       break
     }
     case '31':
@@ -469,7 +469,7 @@ export const calculateOpcodeDynamicFee = (
     case 'f5': {
       result = createCost(common, inputs).iadd(
         toWordSize(new BN(inputs.size)).imuln(
-          Number(common.param('gasPrices', 'sha3Word')),
+          Number(common.param('gasPrices', 'keccak256Word')),
         ),
       )
       break


### PR DESCRIPTION
This fixes a bug where opcodes that relied on the value of sha3 or sha3Word were rendering on the page with a value of 0, giving an incorrect representation of gas fees for the respective opcodes.

This bug appears to be caused by this change in EthereumJS:

https://github.com/ethereumjs/ethereumjs-monorepo/pull/2706/files#diff-aa85288d3ff116040e9adfce5d7d74b582eee859ea89af6cf69cb29f5bccc079

The fix is to switch to the new keccak semantics instead of the deprecated SHA3 semantics.

### Before

![image](https://github.com/smlxl/evm.codes/assets/7783288/0da18466-a5e1-45ca-80d0-ae0412cd75d5)

### After

![image](https://github.com/smlxl/evm.codes/assets/7783288/fd563631-b476-472c-822e-0d8cc965385d)

Related #310