### PR TITLE
chore: upgrade react-tooltip to v5

### DIFF
--- a/components/Editor/ExecutionStatus.tsx
+++ b/components/Editor/ExecutionStatus.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 
 import { useRegisterActions } from 'kbar'
-import ReactTooltip from 'react-tooltip'
+import { Tooltip } from 'react-tooltip'
 
 import { EthereumContext } from 'context/ethereumContext'
 
@@ -45,7 +45,7 @@ const ExecutionStatus = () => {
         </span>
         <span
           className="inline-block mr-4 select-all cursor-help"
-          data-tip="Gas consumed for the current instruction"
+          data-tooltip-content="Gas consumed for the current instruction"
         >
           {executionState.currentGas || 0}
         </span>
@@ -54,12 +54,12 @@ const ExecutionStatus = () => {
         </span>
         <span
           className="inline-block mr-4 select-all cursor-help"
-          data-tip="Total gas consumed"
+          data-tooltip-content="Total gas consumed"
         >
           {executionState.totalGas || 0}
         </span>
 
-        <ReactTooltip className="tooltip" effect="solid" />
+        <Tooltip className="tooltip" />
       </div>
 
       <div>

--- a/components/Editor/SolidityAdvanceModeTab.tsx
+++ b/components/Editor/SolidityAdvanceModeTab.tsx
@@ -351,7 +351,7 @@ const SolidityAdvanceModeTab: FC<Props> = ({
           <Button onClick={handleCopyPermalink} transparent padded={false}>
             <span
               className="inline-block mr-4 select-all"
-              data-tip="Share permalink"
+              data-tooltip-content="Share permalink"
             >
               <Icon name="links-line" className="text-indigo-500 mr-1" />
             </span>

--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -537,7 +537,7 @@ const Editor = ({ readOnly = false }: Props) => {
                     >
                       <span
                         className="inline-block mr-4 select-all"
-                        data-tip="Share permalink"
+                        data-tooltip-content="Share permalink"
                       >
                         <Icon
                           name="links-line"

--- a/components/Reference/index.tsx
+++ b/components/Reference/index.tsx
@@ -13,7 +13,7 @@ import useWindowSize from 'lib/useWindowResize'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useTable, useExpanded, useFilters, HeaderGroup } from 'react-table'
-import ReactTooltip from 'react-tooltip'
+import { Tooltip } from 'react-tooltip'
 import { IReferenceItem, IItemDocs, IGasDocs } from 'types'
 
 import {
@@ -266,13 +266,12 @@ const ReferenceTable = ({
                           !!dynamicFeeForkName && (
                             <span
                               className="inline-block pl-2 text-gray-400 dark:text-black-400"
-                              data-tip="Has additional dynamic gas cost, expand to estimate it"
-                              data-for={`tip-${cell.row.id}`}
+                              data-tooltip-content="Has additional dynamic gas cost, expand to estimate it"
+                              data-tooltip-id={`tip-${cell.row.id}`}
                             >
                               <Icon name="question-line" />
-                              <ReactTooltip
+                              <Tooltip
                                 className="tooltip"
-                                effect="solid"
                                 id={`tip-${cell.row.id}`}
                               />
                             </span>

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import cn from 'classnames'
-import ReactTooltip from 'react-tooltip'
+import { Tooltip } from 'react-tooltip'
 
 type Props = {
   children: React.ReactNode | string
@@ -54,19 +54,15 @@ export const Button: React.FC<Props> = ({
         },
         className,
       )}
-      data-tip={tooltip}
-      data-for={tooltipIdPrefixed}
+      data-tooltip-content={tooltip}
+      data-tooltip-id={tooltipIdPrefixed}
       {...rest}
     >
       <div className={cn('flex items-center', contentClassName)}>
         {children}
       </div>
       {tooltip && tooltipId && (
-        <ReactTooltip
-          className="tooltip"
-          id={tooltipIdPrefixed}
-          effect="solid"
-        />
+        <Tooltip className="tooltip" id={tooltipIdPrefixed} />
       )}
     </button>
   )

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-select": "^5.8.0",
     "react-simple-code-editor": "^0.13.1",
     "react-table": "^7.8.0",
-    "react-tooltip": "^4.2.21",
+    "react-tooltip": "^5.26.4",
     "readable-stream": "^4.5.2",
     "solc": "^0.8.23-fixed",
     "tailwind-merge": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,8 +136,8 @@ dependencies:
     specifier: ^7.8.0
     version: 7.8.0(react@17.0.2)
   react-tooltip:
-    specifier: ^4.2.21
-    version: 4.5.1(react-dom@17.0.2)(react@17.0.2)
+    specifier: ^5.26.4
+    version: 5.26.4(react-dom@17.0.2)(react@17.0.2)
   readable-stream:
     specifier: ^4.5.2
     version: 4.5.2
@@ -1817,11 +1817,24 @@ packages:
       '@floating-ui/utils': 0.2.1
     dev: false
 
+  /@floating-ui/core@1.6.1:
+    resolution: {integrity: sha512-42UH54oPZHPdRHdw6BgoBD6cg/eVTmVrFcgeRDM3jbO7uxSoipVcmcIGFcA5jmOHO5apcyvBhkSKES3fQJnu7A==}
+    dependencies:
+      '@floating-ui/utils': 0.2.2
+    dev: false
+
   /@floating-ui/dom@1.6.3:
     resolution: {integrity: sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==}
     dependencies:
       '@floating-ui/core': 1.6.0
       '@floating-ui/utils': 0.2.1
+    dev: false
+
+  /@floating-ui/dom@1.6.4:
+    resolution: {integrity: sha512-0G8R+zOvQsAG1pg2Q99P21jiqxqGBW1iRe/iXHsBRBxnpXKFI8QwbB4x5KmYLggNO5m34IQgOIu9SCRfR/WWiQ==}
+    dependencies:
+      '@floating-ui/core': 1.6.1
+      '@floating-ui/utils': 0.2.2
     dev: false
 
   /@floating-ui/react-dom@2.0.8(react-dom@17.0.2)(react@17.0.2):
@@ -1830,13 +1843,17 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@floating-ui/dom': 1.6.3
+      '@floating-ui/dom': 1.6.4
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
   /@floating-ui/utils@0.2.1:
     resolution: {integrity: sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==}
+    dev: false
+
+  /@floating-ui/utils@0.2.2:
+    resolution: {integrity: sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw==}
     dev: false
 
   /@humanwhocodes/config-array@0.11.14:
@@ -6770,17 +6787,16 @@ packages:
       react: 17.0.2
     dev: false
 
-  /react-tooltip@4.5.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-Zo+CSFUGXar1uV+bgXFFDe7VeS2iByeIp5rTgTcc2HqtuOS5D76QapejNNfx320MCY91TlhTQat36KGFTqgcvw==}
-    engines: {npm: '>=6.13'}
+  /react-tooltip@5.26.4(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-5WyDrsfw1+6qNVSr3IjqElqJ+cCwE8+44b+HpJ8qRLv7v0a3mcKf8wvv+NfgALFS6QpksGFqTLV2JQ60c+okZQ==}
     peerDependencies:
-      react: '>=16.0.0'
-      react-dom: '>=16.0.0'
+      react: '>=16.14.0'
+      react-dom: '>=16.14.0'
     dependencies:
-      prop-types: 15.8.1
+      '@floating-ui/dom': 1.6.4
+      classnames: 2.5.1
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      uuid: 7.0.3
     dev: false
 
   /react-transition-group@4.4.5(react-dom@17.0.2)(react@17.0.2):
@@ -7963,11 +7979,6 @@ packages:
       is-generator-function: 1.0.10
       is-typed-array: 1.1.13
       which-typed-array: 1.1.15
-    dev: false
-
-  /uuid@7.0.3:
-    resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
-    hasBin: true
     dev: false
 
   /uvu@0.5.6:


### PR DESCRIPTION
## Changes
- upgrade `react-tooltip` from 4.2.21 to 5.26.4
- update imports for `react-tooltip` to use named imports
- update usage of `data-tip` to `data-tooltip-content`
- update usage of `data-for` to `data-tooltip-id`
- remove `effect="solid"` prop which became default in v5

## Test plan
- go to https://evm-codes-git-chore-upgrade-react-tooltip-to-v5-smlxl.vercel.app/playground
- hover over icons to the right of the playground panel
- expect tooltips to work like before