### PR TITLE
chore: note that CREATE fails if target already exists

### DIFF
--- a/docs/opcodes/F0.mdx
+++ b/docs/opcodes/F0.mdx
@@ -16,7 +16,7 @@ The destination address is calculated as the rightmost 20 bytes (160 bits) of th
     address = keccak256(rlp([sender_address,sender_nonce]))[12:]
 
 Deployment can fail due to:
-
+- A contract already exists at the destination address (can happen in combination with [CREATE2](/#F5) and [SELFDESTRUCT](/#FF)).
 - Insufficient value to send.
 - Sub [context](/about) [reverted](/#FD).
 - Insufficient gas to execute the initialisation code.


### PR DESCRIPTION
This adds a note, that `CREATE` fails if there already exists a contract at the target address.

In the normal case, this does not happen as the target address depends on the contracts nonce and the nonce always gets increased by one. However, by (ab-)using `CREATE2`, `SELFDESTRUCT` we can continuously create and destroy a contract that will always have the same initial nonce. From this contract, using `CREATE` will always result in the same address and can lead to conflicts with already existing contracts. Maybe there's also an easier way that leads to conflicts.