### PR TITLE
Fix loading of implementation in code viewer

### DIFF
--- a/components/ContractViewer/index.tsx
+++ b/components/ContractViewer/index.tsx
@@ -83,7 +83,7 @@ const ContractViewerInner = () => {
         return
       }
 
-      return loadDeployment(address, undefined, false, invalidateRoute)
+      return loadDeployment(address, undefined, true, invalidateRoute)
         .then(() => {
           statusCallback({
             status: 'loaded',


### PR DESCRIPTION
Fixes #331 issue reported by high_byte

## Test plan
Verify that USDC implementation is loaded when adding the proxy address `0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48`. Current deployed version does not do this.


<img width="552" alt="Screenshot 2024-06-03 at 12 42 20" src="https://github.com/smlxl/evm.codes/assets/5640782/f27130db-3ffb-427f-8f9f-058a08a04a78">

