### PR TITLE
propagate SoliditySettings when compiling contracts

### DIFF
--- a/util/solc.ts
+++ b/util/solc.ts
@@ -49,19 +49,7 @@ class SolidityCompiler {
     })
   }
 
-  compileCode(code: string | any, version: string, outputSelection: string[]) {
-    const settings: SoliditySettings = {
-      outputSelection: {
-        // the format is a bit weird. here for simplicity apply outputSelection
-        // to all files and all contracts
-        // first key is file filter - asterisk for all files
-        '*': {
-          '': outputSelection, // entire file output selections
-          '*': outputSelection, // per-contract output selections
-        },
-      },
-    }
-
+  compileCode(code: string | any, version: string, settings: SoliditySettings) {
     if (typeof code == 'string') {
       const stdJson = {
         language: 'Solidity',
@@ -77,9 +65,7 @@ class SolidityCompiler {
     } else {
       const stdJson = {
         ...code,
-        settings: {
-          outputSelection: settings.outputSelection,
-        },
+        settings,
       }
 
       return this.compile(stdJson, version)


### PR DESCRIPTION
When you try to view `0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD ` in the Contract Viewer, you get the following compilation errors:
```
[
    {
        "component": "general",
        "errorCode": "6275",
        "formattedMessage": "ParserError: Source \"@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol\" not found: File import callback not supported\n --> contracts/base/Callbacks.sol:4:1:\n  |\n4 | import {IERC721Receiver} from '@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol';\n  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\n",
        "message": "Source \"@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol\" not found: File import callback not supported",
        "severity": "error",
        "sourceLocation": {
            "end": 160,
            "file": "contracts/base/Callbacks.sol",
            "start": 71
        },
        "type": "ParserError"
    },
    ...
]
```

Which leads to frontend errors which you can see in the console: 

![CleanShot 2024-06-11 at 16.06.28@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/dBOcstoDF7rt9xTsg03e/76b74635-7fff-4b75-afa9-58603f4d7203.png)

### The fix
The reason for the above compilation error is that we don't pass in the `remappings` that we get from Etherscan. We need to pass them (and other settings to avoid potentially other errors in the future).

### Test plan
• Try to view `0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD`
• You shouldn't get any errors like in the screenshot above