### PR TITLE
Fix import paths

### DIFF
--- a/util/flatten.ts
+++ b/util/flatten.ts
@@ -114,14 +114,15 @@ export function flattenCode(
     const rel_path =
       imp.path[0] == '.' ? path.join(dirname, imp.path) : imp.path
 
-    const realpath = path.normalize(rel_path).replaceAll('\\', '/')
+    const realPath = path.normalize(rel_path).replaceAll('\\', '/')
+    const remappedRealPath = remapFile(realPath, remappings)
     const preImport = source.slice(index, imp.range[0]).trim() + '\n'
     let flatImport = ''
     flat += preImport
 
-    if (!imported.includes(realpath)) {
+    if (!imported.includes(remappedRealPath)) {
       const countLines = lineOffset + flat.split('\n').length
-      // flat += '/* preimport at ' + countLines + ' of ' + realpath + '*/'
+      // flat += '/* preimport at ' + countLines + ' of ' + realPath + '*/'
 
       // if (lenses) {
       //   lenses.push({
@@ -130,10 +131,10 @@ export function flattenCode(
       //   })
       // }
 
-      imported.push(realpath)
+      imported.push(remappedRealPath)
       flatImport = flattenCode(
         stdJson,
-        realpath,
+        realPath,
         lenses,
         true,
         imported,


### PR DESCRIPTION
If you currently try to compile the flattened version of `0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD` you get an error: 
```
DeclarationError: Identifier already declared.
   --> contracts/test-flatten/UniversalRouter.sol:807:1:
    |
807 | abstract contract ERC20 {
    | ^ (Relevant source part starts here and spans across multiple lines).
Note: The previous declaration is here:
   --> contracts/test-flatten/UniversalRouter.sol:363:1:
    |
363 | abstract contract ERC20 {
    | ^ (Relevant source part starts here and spans across multiple lines).
```

This is because ERC20 is inserted twice into the flattened source code. Our current code tries to handle duplicate insertion but it doesn't take into account remappings. 

In this particular contract ERC20 is import twice in two different files. Once as `solmate/src/tokens/ERC20.sol` and once as `lib/solmate/src/tokens/ERC20.sol`. These are essentially the same file but our code treats them as different files because it doesn't remap imports before checking for duplicates. This PR fixes this.

### Test plan
• Flatten the code of `0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD` in contract viewer
• Copy paste the flattened code into Remix and try compile it.
• You shouldn't get an error like above.