### PR TITLE
fix: `SSTORE` gas

### DIFF
--- a/docs/opcodes/55/berlin.mdx
+++ b/docs/opcodes/55/berlin.mdx
@@ -9,17 +9,14 @@
     static_gas = {gasPrices|sstore}
 
     if value == current_value
-        if key is warm
-            base_dynamic_gas = {gasPrices|warmstorageread}
-        else
-            base_dynamic_gas = {gasPrices|sstoreNoopGasEIP2200}
+        base_dynamic_gas = {gasPrices|warmstorageread}
     else if current_value == original_value
         if original_value == 0
             base_dynamic_gas = {gasPrices|sstoreInitGasEIP2200}
         else
             base_dynamic_gas = {gasPrices|sstoreCleanGasEIP2200}
     else
-        base_dynamic_gas = {gasPrices|sstoreDirtyGasEIP2200}
+        base_dynamic_gas = {gasPrices|warmstorageread}
 
 On top of the cost above, {gasPrices|coldsload} is added to `base_dynamic_gas` if the slot is cold. See section [access sets](/about).
 
@@ -37,14 +34,8 @@ On top of the cost above, {gasPrices|coldsload} is added to `base_dynamic_gas` i
                     gas_refunds += {gasPrices|sstoreClearRefundEIP2200}
             if value == original_value
                 if original_value == 0
-                    if key is warm
-                        gas_refunds += {gasPrices|sstoreInitGasEIP2200} - {gasPrices|warmstorageread}
-                    else
-                        gas_refunds += {gasPrices|sstoreInitRefundEIP2200}
+                    gas_refunds += {gasPrices|sstoreInitGasEIP2200} - {gasPrices|warmstorageread}
                 else
-                    if key is warm
-                        gas_refunds += {gasPrices|sstoreReset} - {gasPrices|coldsload} - {gasPrices|warmstorageread}
-                    else
-                        gas_refunds += {gasPrices|sstoreCleanRefundEIP2200}
+                    gas_refunds += {gasPrices|sstoreReset} - {gasPrices|coldsload} - {gasPrices|warmstorageread}
 
 See [gas refunds](/about).


### PR DESCRIPTION
1. Fix an incorrect and unreachable case of the gas refund computation for `SSTORE`
2.  Fix #312 

## 1.

If and only if the following conditions are met:

```
value != current_value
value == original_value != 0
key is cold
```

The gas refund computation would do:

```
gas_refunds += 4900
```

However, this behaviour is not defined by [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200) and [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929) and the conditions are impossible to reach given that if `original_value != current_value`, it must be that the key is warm.

## 2.

According to both [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200) and [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929), the defined computations are correct and there is no distinct case when the key is cold or warm. There is hence no need for branches.