### PR TITLE
Remove multiple SPDX licenses correctly

### DIFF
--- a/util/flatten.ts
+++ b/util/flatten.ts
@@ -87,7 +87,7 @@ export function flattenCode(
   if (remove_pragma) {
     source = source
       .replace(/^pragma solidity.*$\s*/gm, '')
-      .replace(/^\/\/ SPDX-.*$\s*/gm, '')
+      .replace(/^\s*\/\/\s*SPDX.*$|^\s*\*\s*SPDX.*$/gm, '')
   }
 
   // TODO: fix lenses or remove entirely


### PR DESCRIPTION
Previously it only took into account licenses like this
`// SPDX...`
but it failed to take into account licenses like
`* SPDX ...` which can be part of a multi-line comment.
This PR fixes this.

### Before

https://github.com/smlxl/evm.codes/assets/13179168/9c819c75-3020-495e-8c65-096acf280555

### After

https://github.com/smlxl/evm.codes/assets/13179168/5f6747c6-d1c9-40e5-8869-ec7b82c7b81f

### Test plan
Tested on `0x43506849D7C04F9138D1A2050bbF3A0c054402dd`
