### PR TITLE
Review and align details to current EOF spec

### DIFF
--- a/docs/opcodes/38.mdx
+++ b/docs/opcodes/38.mdx
@@ -9,6 +9,8 @@ group: Environmental Information
 
 Each instruction occupies one byte. In the case of a [PUSH](/#60) instruction, the bytes that need to be pushed are encoded after that, it thus increases the codesize accordingly.
 
+Not allowed in EOFv1 code, code containing this instruction will fail validation.
+
 ## Stack output
 
 0. `size`: byte size of the [code](/about).

--- a/docs/opcodes/39.mdx
+++ b/docs/opcodes/39.mdx
@@ -9,6 +9,8 @@ group: Environmental Information
 
 For out of bound bytes, 0s will be copied.
 
+Not allowed in EOFv1 code, code containing this instruction will fail validation.
+
 ## Stack input
 
 0. `destOffset`: byte offset in the [memory](/about) where the result will be copied.

--- a/docs/opcodes/3B.mdx
+++ b/docs/opcodes/3B.mdx
@@ -5,9 +5,13 @@ group: Environmental Information
 
 *Index 1 is top of the stack. See [PUSH](/#60).*
 
+## Notes
+
+Not allowed in EOFv1 code, code containing this instruction will fail validation.
+
 ## Stack input
 
-0. `address`: 20-byte address of the contract to query.
+0. `address`: 20-byte address of the contract to query. If `address` points to an EOF contract, result is as if its code was `EF00`.
 
 ## Stack output
 

--- a/docs/opcodes/3C.mdx
+++ b/docs/opcodes/3C.mdx
@@ -9,9 +9,11 @@ group: Environmental Information
 
 For out of bound bytes, 0s will be copied.
 
+Not allowed in EOFv1 code, code containing this instruction will fail validation.
+
 ## Stack input
 
-0. `address`: 20-byte address of the contract to query.
+0. `address`: 20-byte address of the contract to query. If `address` points to an EOF contract, result is as if its code was `EF00`.
 1. `destOffset`: byte offset in the [memory](/about) where the result will be copied.
 2. `offset`: byte offset in the [code](/about) to copy.
 3. `size`: byte size to copy.

--- a/docs/opcodes/3E.mdx
+++ b/docs/opcodes/3E.mdx
@@ -51,4 +51,4 @@ The state changes done by the current context are [reverted](#FD) in those cases
 - Not enough gas.
 - Not enough values on the stack.
 - The addition `offset` + `size` overflows.
-- `offset` + `size` is larger than [RETURNDATASIZE](#3D), if executed in legacy code.
+- `offset` + `size` is larger than [RETURNDATASIZE](#3D), if executed in legacy (non-EOF) code.

--- a/docs/opcodes/3E.mdx
+++ b/docs/opcodes/3E.mdx
@@ -9,6 +9,8 @@ group: Environmental Information
 
 A sub context can be created with [CALL](/#F1), [CALLCODE](/#F2), [DELEGATECALL](/#F4) or [STATICCALL](/#FA).
 
+If executed in EOF code, for out of bound bytes, 0s will be copied.
+
 ## Stack input
 
 0. `destOffset`: byte offset in the [memory](/about) where the result will be copied.
@@ -49,4 +51,4 @@ The state changes done by the current context are [reverted](#FD) in those cases
 - Not enough gas.
 - Not enough values on the stack.
 - The addition `offset` + `size` overflows.
-- `offset` + `size` is larger than [RETURNDATASIZE](#3D).
+- `offset` + `size` is larger than [RETURNDATASIZE](#3D), if executed in legacy code.

--- a/docs/opcodes/3F.mdx
+++ b/docs/opcodes/3F.mdx
@@ -5,9 +5,13 @@ group: Environmental Information
 
 *Index 1 is top of the stack. See [PUSH](/#60).*
 
+## Notes
+
+Not allowed in EOFv1 code, code containing this instruction will fail validation.
+
 ## Stack input
 
-0. `address`: 20-byte address of the account.
+0. `address`: 20-byte address of the account. If `address` points to an EOF contract, result is as if its code was `EF00`.
 
 ## Stack output
 

--- a/docs/opcodes/55.mdx
+++ b/docs/opcodes/55.mdx
@@ -37,5 +37,5 @@ group: Stack Memory Storage and Flow Operations
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Not enough values on the stack.
-- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).
 - When the amount of gas left to the transaction is less than or equal 2300 (since Istanbul fork).

--- a/docs/opcodes/55.mdx
+++ b/docs/opcodes/55.mdx
@@ -37,5 +37,5 @@ group: Stack Memory Storage and Flow Operations
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Not enough values on the stack.
-- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since EOF fork).
 - When the amount of gas left to the transaction is less than or equal 2300 (since Istanbul fork).

--- a/docs/opcodes/56.mdx
+++ b/docs/opcodes/56.mdx
@@ -11,6 +11,8 @@ The program counter (PC) is a byte offset in the deployed [code](/about). It ind
 
 The **JUMP** instruction alters the program counter, thus breaking the linear path of the execution to another point in the deployed [code](/about). It is used to implement functionalities like functions.
 
+Not allowed in EOFv1 code, code containing this instruction will fail validation.
+
 ## Stack input
 
 0. `counter`: byte offset in the deployed [code](/about) where execution will continue from. Must be a [JUMPDEST](/#5B) instruction.

--- a/docs/opcodes/57.mdx
+++ b/docs/opcodes/57.mdx
@@ -11,6 +11,8 @@ The program counter (PC) is a byte offset in the deployed [code](/about). It ind
 
 The **JUMPI** instruction may alter the program counter, thus breaking the linear path of the execution to another point in the deployed [code](/about). It is used to implement functionalities like loops and conditions.
 
+Not allowed in EOFv1 code, code containing this instruction will fail validation.
+
 ## Stack input
 
 0. `counter`: byte offset in the deployed [code](/about) where execution will continue from. Must be a [JUMPDEST](/#5B) instruction.

--- a/docs/opcodes/58.mdx
+++ b/docs/opcodes/58.mdx
@@ -9,6 +9,8 @@ group: Stack Memory Storage and Flow Operations
 
 The program counter (PC) is a byte offset in the deployed [code](/about). It indicates which instruction will be executed next. When an [ADD](/#01) is executed, for example, the PC is incremented by 1, since the instruction is 1 byte. The [PUSH](/#60) instructions are bigger than one byte, and so will increment the counter accordingly.
 
+Not allowed in EOFv1 code, code containing this instruction will fail validation.
+
 ## Stack output
 
 0. `counter`: PC of this instruction in the current program.

--- a/docs/opcodes/5A.mdx
+++ b/docs/opcodes/5A.mdx
@@ -5,6 +5,10 @@ group: Stack Memory Storage and Flow Operations
 
 *Index 1 is top of the stack. See [PUSH](/#60).*
 
+## Notes
+
+Not allowed in EOFv1 code, code containing this instruction will fail validation.
+
 ## Stack output
 
 0. `gas`: remaining gas (after this instruction).

--- a/docs/opcodes/5B.mdx
+++ b/docs/opcodes/5B.mdx
@@ -7,4 +7,4 @@ group: Stack Memory Storage and Flow Operations
 
 Mark a valid destination for [JUMP](/#56) or [JUMPI](/#57). This operation has no effect on machine state during execution.
 
-Has no effect whatsoever on validation or execution of EOF code, where it is renamed to `NOOP`.
+Has no effect whatsoever on validation or execution of EOF code, where it is renamed to `NOP`.

--- a/docs/opcodes/5B.mdx
+++ b/docs/opcodes/5B.mdx
@@ -5,4 +5,6 @@ group: Stack Memory Storage and Flow Operations
 
 ## Notes
 
-Mark a valid destination for [JUMP](/#56) or [JUMPI](/#57). This operation has no effect on machine state during execution. Has no effect on execution in EOF code, where it is called `NOOP`.
+Mark a valid destination for [JUMP](/#56) or [JUMPI](/#57). This operation has no effect on machine state during execution.
+
+Has no effect whatsoever on validation or execution of EOF code, where it is renamed to `NOOP`.

--- a/docs/opcodes/5B.mdx
+++ b/docs/opcodes/5B.mdx
@@ -5,4 +5,4 @@ group: Stack Memory Storage and Flow Operations
 
 ## Notes
 
-Mark a valid destination for [JUMP](/#56) or [JUMPI](/#57). This operation has no effect on machine state during execution.
+Mark a valid destination for [JUMP](/#56) or [JUMPI](/#57). This operation has no effect on machine state during execution. Has no effect on execution in EOF code, where it is called `NOOP`.

--- a/docs/opcodes/A0.mdx
+++ b/docs/opcodes/A0.mdx
@@ -19,4 +19,4 @@ This instruction has no effect on the EVM state. See [here](https://ethereum.org
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Not enough values on the stack.
-- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since EOF fork).

--- a/docs/opcodes/A0.mdx
+++ b/docs/opcodes/A0.mdx
@@ -19,4 +19,4 @@ This instruction has no effect on the EVM state. See [here](https://ethereum.org
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Not enough values on the stack.
-- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).

--- a/docs/opcodes/A1.mdx
+++ b/docs/opcodes/A1.mdx
@@ -20,4 +20,4 @@ This instruction has no effect on the EVM state. See [here](https://ethereum.org
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Not enough values on the stack.
-- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since EOF fork).

--- a/docs/opcodes/A1.mdx
+++ b/docs/opcodes/A1.mdx
@@ -20,4 +20,4 @@ This instruction has no effect on the EVM state. See [here](https://ethereum.org
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Not enough values on the stack.
-- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).

--- a/docs/opcodes/A2.mdx
+++ b/docs/opcodes/A2.mdx
@@ -21,4 +21,4 @@ This instruction has no effect on the EVM state. See [here](https://ethereum.org
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Not enough values on the stack.
-- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since EOF fork).

--- a/docs/opcodes/A2.mdx
+++ b/docs/opcodes/A2.mdx
@@ -21,4 +21,4 @@ This instruction has no effect on the EVM state. See [here](https://ethereum.org
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Not enough values on the stack.
-- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).

--- a/docs/opcodes/A3.mdx
+++ b/docs/opcodes/A3.mdx
@@ -22,4 +22,4 @@ This instruction has no effect on the EVM state. See [here](https://ethereum.org
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Not enough values on the stack.
-- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).

--- a/docs/opcodes/A3.mdx
+++ b/docs/opcodes/A3.mdx
@@ -22,4 +22,4 @@ This instruction has no effect on the EVM state. See [here](https://ethereum.org
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Not enough values on the stack.
-- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since EOF fork).

--- a/docs/opcodes/A4.mdx
+++ b/docs/opcodes/A4.mdx
@@ -23,4 +23,4 @@ This instruction has no effect on the EVM state. See [here](https://ethereum.org
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Not enough values on the stack.
-- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since EOF fork).

--- a/docs/opcodes/A4.mdx
+++ b/docs/opcodes/A4.mdx
@@ -23,4 +23,4 @@ This instruction has no effect on the EVM state. See [here](https://ethereum.org
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Not enough values on the stack.
-- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).

--- a/docs/opcodes/D0.mdx
+++ b/docs/opcodes/D0.mdx
@@ -29,5 +29,4 @@ group: Data Section Access
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Not enough values on the stack.
 - Legacy bytecode.

--- a/docs/opcodes/D0.mdx
+++ b/docs/opcodes/D0.mdx
@@ -29,4 +29,4 @@ group: Data Section Access
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Legacy bytecode.
+- Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/D1.mdx
+++ b/docs/opcodes/D1.mdx
@@ -29,5 +29,4 @@ group: Data Section Access
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Not enough values on the stack.
 - Legacy bytecode.

--- a/docs/opcodes/D1.mdx
+++ b/docs/opcodes/D1.mdx
@@ -29,4 +29,4 @@ group: Data Section Access
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Legacy bytecode.
+- Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/D2.mdx
+++ b/docs/opcodes/D2.mdx
@@ -25,5 +25,4 @@ group: Data Section Access
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Not enough values on the stack.
 - Legacy bytecode.

--- a/docs/opcodes/D2.mdx
+++ b/docs/opcodes/D2.mdx
@@ -25,4 +25,4 @@ group: Data Section Access
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Legacy bytecode.
+- Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/D3.mdx
+++ b/docs/opcodes/D3.mdx
@@ -5,6 +5,10 @@ group: Data Section Access
 
 *Index 1 is top of the stack. See [PUSH](/#60).*
 
+## Notes
+
+For out of bound bytes, 0s will be copied.
+
 ## Stack input
 
 0. `mem_offset`: byte offset in the [memory](/about) where the result will be copied to.
@@ -31,5 +35,4 @@ group: Data Section Access
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Not enough values on the stack.
 - Legacy bytecode.

--- a/docs/opcodes/D3.mdx
+++ b/docs/opcodes/D3.mdx
@@ -35,4 +35,4 @@ For out of bound bytes, 0s will be copied.
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Legacy bytecode.
+- Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/E0.mdx
+++ b/docs/opcodes/E0.mdx
@@ -9,7 +9,7 @@ group: Stack Memory Storage and Flow Operations
 
 The program counter (PC) is a byte offset in the deployed [code](/about). It indicates which instruction will be executed next. When an [ADD](/#01) is executed, for example, the PC is incremented by 1, since the instruction is 1 byte. The [PUSH](/#60) instructions are bigger than one byte, and so will increment the counter accordingly.
 
-The **RJUMP** instruction alters the program counter with relative offset, thus breaking the linear path of the execution to another point in the deployed [code](/about). It is used to implement functionalities like functions.
+The **RJUMP** instruction alters the program counter with relative offset, thus breaking the linear path of the execution to another point in the deployed [code](/about). It is used to implement functionalities like loops.
 
 It offer reduced gas cost compare to dynamic counterpart.
 
@@ -25,6 +25,4 @@ It offer reduced gas cost compare to dynamic counterpart.
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Not enough values on the stack.
 - Legacy bytecode.
-- Target outside of code bounds, or another immediate argument.

--- a/docs/opcodes/E0.mdx
+++ b/docs/opcodes/E0.mdx
@@ -25,4 +25,4 @@ It offer reduced gas cost compare to dynamic counterpart.
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Legacy bytecode.
+- Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/E1.mdx
+++ b/docs/opcodes/E1.mdx
@@ -27,4 +27,4 @@ The **RJUMPI** instruction may alter the program counter with relative offset, t
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Legacy bytecode.
+- Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/E1.mdx
+++ b/docs/opcodes/E1.mdx
@@ -27,6 +27,4 @@ The **RJUMPI** instruction may alter the program counter with relative offset, t
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Not enough values on the stack.
 - Legacy bytecode.
-- Target outside of code bounds, or an immediate operand.

--- a/docs/opcodes/E2.mdx
+++ b/docs/opcodes/E2.mdx
@@ -11,7 +11,7 @@ The program counter (PC) is a byte offset in the deployed [code](/about). It ind
 
 The **RJUMPV** instruction may alter the program counter with relative offset, thus breaking the linear path of the execution to another point in the deployed [code](/about). It is used to implement functionalities like switch statements. if `case > max_index` (out-of-bounds case), fall through and increment the counter by `(max_index + 1) * 2` without `relative_offset` takes into account.
 
-An interesting feature is that `RJUMPV 0 relative_offset` is an inverted-[RJUMPI](/#E1), which can be used in many cases.
+An interesting feature is that `RJUMPV 0 relative_offset` is an inverted-[RJUMPI](/#E1), which can be used in many cases instead of `ISZERO RJUMPI relative_offset`.
 
 It offer reduced gas cost (both at deploy and execution time) and better analysis properties.
 
@@ -32,4 +32,4 @@ It offer reduced gas cost (both at deploy and execution time) and better analysi
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Legacy bytecode.
+- Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/E2.mdx
+++ b/docs/opcodes/E2.mdx
@@ -9,7 +9,7 @@ group: Stack Memory Storage and Flow Operations
 
 The program counter (PC) is a byte offset in the deployed [code](/about). It indicates which instruction will be executed next. When an [ADD](/#01) is executed, for example, the PC is incremented by 1, since the instruction is 1 byte. The [PUSH](/#60) instructions are bigger than one byte, and so will increment the counter accordingly.
 
-The **RJUMPV** instruction may alter the program counter with relative offset, thus breaking the linear path of the execution to another point in the deployed [code](/about). It is used to implement functionalities like loops and conditions. if `case > max_index` (out-of-bounds case), fall through and increment the counter by `(max_index + 1) * 2` without `relative_offset` takes into account.
+The **RJUMPV** instruction may alter the program counter with relative offset, thus breaking the linear path of the execution to another point in the deployed [code](/about). It is used to implement functionalities like switch statements. if `case > max_index` (out-of-bounds case), fall through and increment the counter by `(max_index + 1) * 2` without `relative_offset` takes into account.
 
 An interesting feature is that `RJUMPV 0 relative_offset` is an inverted-[RJUMPI](/#E1), which can be used in many cases.
 
@@ -32,6 +32,4 @@ It offer reduced gas cost (both at deploy and execution time) and better analysi
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Not enough values on the stack.
 - Legacy bytecode.
-- Target outside of code bounds, or an immediate operand.

--- a/docs/opcodes/E3.mdx
+++ b/docs/opcodes/E3.mdx
@@ -11,8 +11,6 @@ A new return stack is introduced, it is a stack of items representing execution 
 
 The **CALLF** instruction call into a function or subroutine with given metadata index in the type section, then push an execution state onto the return stack. 
 
-Within these functions/subroutines static jump instructions are preferred, dynamic jump instructions are disallowed.
-
 ## Immediate argument
 
 0. `target_section_index`: 16-bit unsigned value as metadata index in the type section of EOF container corresponds to a code section index
@@ -27,4 +25,4 @@ The state changes done by the current context are [reverted](#FD) in those cases
 - Not enough gas.
 - Return stack already has 1024 items.
 - The called function exceed the global stack height limit.
-- Legacy bytecode.
+- Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/E3.mdx
+++ b/docs/opcodes/E3.mdx
@@ -11,7 +11,7 @@ A new return stack is introduced, it is a stack of items representing execution 
 
 The **CALLF** instruction call into a function or subroutine with given metadata index in the type section, then push an execution state onto the return stack. 
 
-Static jump instructions are prefered, dynamic jump instructions are disallowed.
+Within these functions/subroutines static jump instructions are preferred, dynamic jump instructions are disallowed.
 
 ## Immediate argument
 
@@ -25,7 +25,6 @@ Static jump instructions are prefered, dynamic jump instructions are disallowed.
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Not enough values on the stack.
-- Target section index is exceed or equal number of code section.
 - Return stack already has 1024 items.
 - The called function exceed the global stack height limit.
+- Legacy bytecode.

--- a/docs/opcodes/E4.mdx
+++ b/docs/opcodes/E4.mdx
@@ -9,8 +9,6 @@ group: Subroutine and Function
 
 Context from [CALLF](/#E3), The **RETF** instruction return value from a function or subroutine, which pop an execution state from return stack and set to corresponding values (current section index, program counter).
 
-Within these functions/subroutines static jump instructions are preferred, dynamic jump instructions are disallowed.
-
 ## Example
 
 *TBD: Reproduce in playground*
@@ -19,4 +17,4 @@ Within these functions/subroutines static jump instructions are preferred, dynam
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Legacy bytecode.
+- Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/E4.mdx
+++ b/docs/opcodes/E4.mdx
@@ -19,5 +19,4 @@ Within these functions/subroutines static jump instructions are preferred, dynam
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Not enough values on the stack.
-- Return stack is empty resulting in end execution or exceptionally halt.
+- Legacy bytecode.

--- a/docs/opcodes/E5.mdx
+++ b/docs/opcodes/E5.mdx
@@ -21,5 +21,5 @@ This allow us to chain function calls, while allow compiler to optimise code siz
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Not enough values on the stack.
 - Operand stack size exceed global stack height limit.
+- Legacy bytecode.

--- a/docs/opcodes/E5.mdx
+++ b/docs/opcodes/E5.mdx
@@ -22,4 +22,4 @@ This allow us to chain function calls, while allow compiler to optimise code siz
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Operand stack size exceed global stack height limit.
-- Legacy bytecode.
+- Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/E6.mdx
+++ b/docs/opcodes/E6.mdx
@@ -17,6 +17,4 @@ group: Exchange Operations
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Not enough values on the stack.
 - Legacy bytecode.
-- Stack overflow.

--- a/docs/opcodes/E6.mdx
+++ b/docs/opcodes/E6.mdx
@@ -17,4 +17,4 @@ group: Exchange Operations
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Legacy bytecode.
+- Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/E7.mdx
+++ b/docs/opcodes/E7.mdx
@@ -17,5 +17,4 @@ group: Exchange Operations
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Not enough values on the stack.
 - Legacy bytecode.

--- a/docs/opcodes/E7.mdx
+++ b/docs/opcodes/E7.mdx
@@ -17,4 +17,4 @@ group: Exchange Operations
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Legacy bytecode.
+- Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/E8.mdx
+++ b/docs/opcodes/E8.mdx
@@ -19,4 +19,4 @@ group: Exchange Operations
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Legacy bytecode.
+- Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/E8.mdx
+++ b/docs/opcodes/E8.mdx
@@ -7,9 +7,11 @@ group: Exchange Operations
 
 ## Immediate argument
 
-0. `stack_index`: index of item to swap between the first and second nibbles of the item
+0. `imm`: 1 byte containing indices of stack items to swap. Given `n = imm >> 4 + 1`, `m = imm & 0x0F + 1`, `n + 1`th stack item is swapped with `n + m + 1`th. 
 
 ## Example
+
+`E800` will swap the 2nd and 3rd stack item, `E8FF` will swap the 17th and 33rd stack item.
 
 *TBD: Reproduce in playground*
 
@@ -17,5 +19,4 @@ group: Exchange Operations
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Not enough values on the stack.
 - Legacy bytecode.

--- a/docs/opcodes/EC.mdx
+++ b/docs/opcodes/EC.mdx
@@ -46,7 +46,7 @@ Note that these failures only affect the return value and do not cause the calli
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Not enough values on the stack.
-- The current execution context is from a [EXTSTATICCALL](/#FB).
+- The current execution context is from a [EXTSTATICCALL](/#FB) (since Prague fork).
 - Deploy container code size exceed maximum code size, which is updated within [RETURNCONTRACT](/#EE).
 - `input_size` is greater than the chain's maximum initcode size (since Shanghai fork).
+- Legacy bytecode.

--- a/docs/opcodes/EC.mdx
+++ b/docs/opcodes/EC.mdx
@@ -48,4 +48,4 @@ The state changes done by the current context are [reverted](#FD) in those cases
 - Not enough gas.
 - The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).
 - Deploy container code size exceed maximum code size, which is updated within [RETURNCONTRACT](/#EE).
-- Legacy bytecode.
+- Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/EC.mdx
+++ b/docs/opcodes/EC.mdx
@@ -46,7 +46,6 @@ Note that these failures only affect the return value and do not cause the calli
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- The current execution context is from a [EXTSTATICCALL](/#FB) (since Prague fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).
 - Deploy container code size exceed maximum code size, which is updated within [RETURNCONTRACT](/#EE).
-- `input_size` is greater than the chain's maximum initcode size (since Shanghai fork).
 - Legacy bytecode.

--- a/docs/opcodes/EC.mdx
+++ b/docs/opcodes/EC.mdx
@@ -46,6 +46,6 @@ Note that these failures only affect the return value and do not cause the calli
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since EOF fork).
 - Deploy container code size exceed maximum code size, which is updated within [RETURNCONTRACT](/#EE).
 - Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/EC/EOF.mdx
+++ b/docs/opcodes/EC/EOF.mdx
@@ -1,15 +1,14 @@
 ## Gas
 
     minimum_word_size = (initcontainer_size + 31) / 32
-    init_code_cost = {gasPrices|initCodeWordGas} * minimum_word_size
     hash_cost = {gasPrices|keccak256WordGas} * minimum_word_size
     code_deposit_cost = {gasPrices|createDataGas} * deployed_code_size
 
     static_gas = {gasPrices|eofcreateGas}
-    dynamic_gas = init_code_cost + hash_cost + memory_expansion_cost + deployment_code_execution_cost + code_deposit_cost
+    dynamic_gas = hash_cost + memory_expansion_cost + deployment_code_execution_cost + code_deposit_cost
 
 The `deployment_code_execution_cost` is the cost of whatever opcode is run to deploy the new contract. 
-On top of that, there are additional costs for storing the code of the new contract, respectively shown as `code_deposit_cost` and `init_code_cost`.
+On top of that, there are additional costs for storing the code of the new contract, respectively shown as `code_deposit_cost`.
 The memory expansion cost explanation can be found [here](/about).
 
 The new contract address is added in the warm addresses. See section [access sets](/about).

--- a/docs/opcodes/EE.mdx
+++ b/docs/opcodes/EE.mdx
@@ -32,4 +32,4 @@ The state changes done by the current context are [reverted](#FD) in those cases
 - Not enough gas.
 - After appending, the data section size is less than declared in the header or exceeds the maximum data section size.
 - After appending, the container size exceeds the maximum code size limit.
-- Legacy bytecode.
+- Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/EE.mdx
+++ b/docs/opcodes/EE.mdx
@@ -30,7 +30,6 @@ Should deployment succeed, the account's [code](/about) is set to the [return da
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Not enough values on the stack.
-- The current execution context is from a [EXTSTATICCALL](/#FB).
 - Exceed the maximum data section size.
-- Less than data section size declared in the header.
+- After appending, the data section size is less than declared in the header.
+- Legacy bytecode.

--- a/docs/opcodes/EE.mdx
+++ b/docs/opcodes/EE.mdx
@@ -30,6 +30,6 @@ Should deployment succeed, the account's [code](/about) is set to the [return da
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Exceed the maximum data section size.
-- After appending, the data section size is less than declared in the header.
+- After appending, the data section size is less than declared in the header or exceeds the maximum data section size.
+- After appending, the container size exceeds the maximum code size limit.
 - Legacy bytecode.

--- a/docs/opcodes/F0.mdx
+++ b/docs/opcodes/F0.mdx
@@ -24,6 +24,8 @@ Deployment can fail due to:
 
 Note that these failures only affect the return value and do not cause the calling context to revert (unlike the error cases below).
 
+Not allowed in EOFv1 code, code containing this instruction will fail validation.
+
 ## Stack input
 
 0. `value`: value in [wei](https://www.investopedia.com/terms/w/wei.asp) to send to the new account.
@@ -44,5 +46,5 @@ The state changes done by the current context are [reverted](#FD) in those cases
 
 - Not enough gas.
 - Not enough values on the stack.
-- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).
 - `size` is greater than the chain's maximum initcode size (since Shanghai fork).

--- a/docs/opcodes/F0.mdx
+++ b/docs/opcodes/F0.mdx
@@ -46,5 +46,5 @@ The state changes done by the current context are [reverted](#FD) in those cases
 
 - Not enough gas.
 - Not enough values on the stack.
-- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since EOF fork).
 - `size` is greater than the chain's maximum initcode size (since Shanghai fork).

--- a/docs/opcodes/F1.mdx
+++ b/docs/opcodes/F1.mdx
@@ -15,6 +15,8 @@ From the Tangerine Whistle fork, `gas` is capped at all but one 64th (`remaining
 
 If the caller doesn't have enough balance to send the [value](/#34), the call fails but the current [context](/about) is not reverted.
 
+Not allowed in EOFv1 code, code containing this instruction will fail validation.
+
 ## Stack input
 
 0. `gas`: amount of gas to send to the sub [context](/about) to execute. The gas that is not used by the sub context is returned to this one.
@@ -38,4 +40,4 @@ If the caller doesn't have enough balance to send the [value](/#34), the call fa
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Not enough values on the stack.
-- The current execution context is from a [STATICCALL](/#FA) and the [value](/#34) (stack index 2) is not 0 (since Byzantium fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork) and the [value](/#34) is not 0.

--- a/docs/opcodes/F1.mdx
+++ b/docs/opcodes/F1.mdx
@@ -40,4 +40,4 @@ Not allowed in EOFv1 code, code containing this instruction will fail validation
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Not enough values on the stack.
-- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork) and the [value](/#34) is not 0.
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since EOF fork) and the [value](/#34) is not 0.

--- a/docs/opcodes/F2.mdx
+++ b/docs/opcodes/F2.mdx
@@ -15,6 +15,8 @@ From the Tangerine Whistle fork, `gas` is capped at all but one 64th (`remaining
 
 If the caller doesn't have enough balance to send the [value](/#34), the call fails but the current [context](/about) is not reverted.
 
+Not allowed in EOFv1 code, code containing this instruction will fail validation.
+
 ## Stack input
 
 0. `gas`: amount of gas to send to the sub [context](/about) to execute. The gas that is not used by the sub context is returned to this one.

--- a/docs/opcodes/F4.mdx
+++ b/docs/opcodes/F4.mdx
@@ -13,6 +13,8 @@ If the size of the [return data](/about) is not known, it can also be retrieved 
 
 From the Tangerine Whistle fork, `gas` is capped at all but one 64th (`remaining_gas / 64`) of the remaining gas of the current context. If a call tries to send more, the `gas` is changed to match the maximum allowed.
 
+Not allowed in EOFv1 code, code containing this instruction will fail validation.
+
 ## Stack input
 
 0. `gas`: amount of gas to send to the sub [context](/about) to execute. The gas that is not used by the sub context is returned to this one.

--- a/docs/opcodes/F5.mdx
+++ b/docs/opcodes/F5.mdx
@@ -47,5 +47,5 @@ Not allowed in EOFv1 code, code containing this instruction will fail validation
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Not enough values on the stack.
-- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since EOF fork).
 - `size` is greater than the chain's maximum initcode size (since Shanghai fork).

--- a/docs/opcodes/F5.mdx
+++ b/docs/opcodes/F5.mdx
@@ -25,6 +25,8 @@ Deployment can fail due to:
 
 Note that these failures only affect the return value and do not cause the calling context to revert (unlike the error cases below).
 
+Not allowed in EOFv1 code, code containing this instruction will fail validation.
+
 ## Stack input
 
 0. `value`: value in [wei](https://www.investopedia.com/terms/w/wei.asp) to send to the new account.
@@ -45,5 +47,5 @@ Note that these failures only affect the return value and do not cause the calli
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Not enough values on the stack.
-- The current execution context is from a [STATICCALL](/#FA).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).
 - `size` is greater than the chain's maximum initcode size (since Shanghai fork).

--- a/docs/opcodes/F7.mdx
+++ b/docs/opcodes/F7.mdx
@@ -7,8 +7,6 @@ group: Environmental Information
 
 ## Notes
 
-A sub context can be created with [EXTCALL](/#F8), [EXTDELEGATECALL](/#F9) or [EXTSTATICCALL](/#FB). 
-
 The **RETURNDATALOAD** is used to load 32 bytes word from return data, and push it onto the memory stack, if return data is less than 32 bytes, the value is zero-padded (same behavior as [CALLDATALOAD](/#35)).
 
 ## Stack input

--- a/docs/opcodes/F7.mdx
+++ b/docs/opcodes/F7.mdx
@@ -39,4 +39,4 @@ The **RETURNDATALOAD** is used to load 32 bytes word from return data, and push 
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Not enough values on the stack.
+- Legacy bytecode.

--- a/docs/opcodes/F7.mdx
+++ b/docs/opcodes/F7.mdx
@@ -39,4 +39,4 @@ The **RETURNDATALOAD** is used to load 32 bytes word from return data, and push 
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Legacy bytecode.
+- Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/F8.mdx
+++ b/docs/opcodes/F8.mdx
@@ -9,9 +9,13 @@ group: System operations
 
 Creates a new sub [context](/about) and execute the [code](/about) of the given account, then resumes the current one. Note that an account with no code will return success status.
 
-If the size of the [return data](/about) is not known, it can also be retrieved after the call with the instructions [RETURNDATASIZE](/#3D) and [RETURNDATACOPY](/#3E) (since the Byzantium fork), or load 32-byte word onto the stack with [RETURNDATALOAD](/#F7) instruction.
+The size of the [return data](/about) can be retrieved after the call with the instructions [RETURNDATASIZE](/#3D) and [RETURNDATACOPY](/#3E) (since the Byzantium fork), or load 32-byte word onto the stack with [RETURNDATALOAD](/#F7) instruction.
 
-If the caller doesn't have enough balance to send the [value](/#34), the call fails but the current [context](/about) is not reverted.
+If the caller doesn't have enough balance to send the [value](/#34), the call fails returning 1 as `status`, but the current [context](/about) is not reverted.
+
+All but one 64th (`remaining_gas / 64`) of the remaining gas of the current context is sent to the sub [context](/about) to execute, but no less than 2300. The gas that is not used by the sub context is returned to this one. In case gas not sent would be lower than 5000, the call fails returning 1 as `status`, but the current [context](/about) is not reverted.
+
+If the call stack depth is 1024, the call fails returning 1 as `status`, but the current [context](/about) is not reverted.
 
 ## Stack input
 
@@ -32,8 +36,5 @@ If the caller doesn't have enough balance to send the [value](/#34), the call fa
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Not enough values on the stack.
-- Call stack depth is 1024
 - The target address has more than 20 bytes. 
-- The target account code is legacy code (pre-EOF).
-- The current execution context is from a [STATICCALL](/#FA) and the [value](/#34) (stack index 2) is not 0 (since Byzantium fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork) and the [value](/#34) is not 0.

--- a/docs/opcodes/F8.mdx
+++ b/docs/opcodes/F8.mdx
@@ -37,5 +37,5 @@ If the call stack depth is 1024, the call fails returning 1 as `status`, but the
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - The target address has more than 20 bytes. 
-- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork) and the [value](/#34) is not 0.
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since EOF fork) and the [value](/#34) is not 0.
 - Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/F8.mdx
+++ b/docs/opcodes/F8.mdx
@@ -38,3 +38,4 @@ The state changes done by the current context are [reverted](#FD) in those cases
 - Not enough gas.
 - The target address has more than 20 bytes. 
 - The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork) and the [value](/#34) is not 0.
+- Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/F9.mdx
+++ b/docs/opcodes/F9.mdx
@@ -35,3 +35,4 @@ The state changes done by the current context are [reverted](#FD) in those cases
 - Not enough gas.
 - The target address has more than 20 bytes.
 - The target account code is legacy code (pre-EOF).
+- Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/F9.mdx
+++ b/docs/opcodes/F9.mdx
@@ -9,9 +9,11 @@ group: System operations
 
 Creates a new sub [context](/about) as if calling itself, but with the [code](/about) of the given account. In particular the [storage](/about) remains the same. Note that an account with no code will return success status.
 
-If the size of the [return data](/about) is not known, it can also be retrieved after the call with the instructions [RETURNDATASIZE](/#3D) and [RETURNDATACOPY](/#3E) (since the Byzantium fork), or load 32-byte word onto the stack with [RETURNDATALOAD](/#F7) instruction.
+The size of the [return data](/about) can be retrieved after the call with the instructions [RETURNDATASIZE](/#3D) and [RETURNDATACOPY](/#3E) (since the Byzantium fork), or load 32-byte word onto the stack with [RETURNDATALOAD](/#F7) instruction.
 
-If the caller doesn't have enough balance to send the [value](/#34), the call fails but the current [context](/about) is not reverted.
+All but one 64th (`remaining_gas / 64`) of the remaining gas of the current context is sent to the sub [context](/about) to execute, but no less than 2300. The gas that is not used by the sub context is returned to this one. In case gas not sent would be lower than 5000, the call fails returning 1 as `status`, but the current [context](/about) is not reverted.
+
+If the call stack depth is 1024, the call fails returning 1 as `status`, but the current [context](/about) is not reverted.
 
 ## Stack input
 
@@ -31,6 +33,5 @@ If the caller doesn't have enough balance to send the [value](/#34), the call fa
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Not enough values on the stack.
 - The target address has more than 20 bytes.
 - The target account code is legacy code (pre-EOF).

--- a/docs/opcodes/FA.mdx
+++ b/docs/opcodes/FA.mdx
@@ -9,11 +9,13 @@ group: System operations
 
 Creates a new sub [context](/about) and execute the [code](/about) of the given account, then resumes the current one. Note that an account with no code will return success as true (1).
 
-This instructions is equivalent to [CALL](/#F1), except that it does not allow any state modifying instructions or sending ETH in the sub [context](/about). The disallowed instructions are [CREATE](/#F0), [CREATE2](/#F5), [LOG0](/#A0), [LOG1](/#A1), [LOG2](/#A2), [LOG3](/#A3), [LOG4](/#A4), [SSTORE](/#55), [SELFDESTRUCT](/#FF) and [CALL](/#F1) if the [value](/#34) sent is not 0.
+This instructions is equivalent to [CALL](/#F1), except that it does not allow any state modifying instructions or sending ETH in the sub [context](/about). The disallowed instructions are [CREATE](/#F0), [CREATE2](/#F5), [LOG0](/#A0), [LOG1](/#A1), [LOG2](/#A2), [LOG3](/#A3), [LOG4](/#A4), [SSTORE](/#55), [SELFDESTRUCT](/#FF), [EOFCREATE](/#EC), as well as [CALL](/#F1) or [EXTCALL](/#F8) if the [value](/#34) sent is not 0.
 
 If the size of the [return data](/about) is not known, it can also be retrieved after the call with the instructions [RETURNDATASIZE](/#3D) and [RETURNDATACOPY](/#3E) (since the Byzantium fork).
 
 From the Tangerine Whistle fork, `gas` is capped at all but one 64th (`remaining_gas / 64`) of the remaining gas of the current context. If a call tries to send more, the `gas` is changed to match the maximum allowed.
+
+Not allowed in EOFv1 code, code containing this instruction will fail validation.
 
 ## Stack input
 

--- a/docs/opcodes/FB.mdx
+++ b/docs/opcodes/FB.mdx
@@ -36,3 +36,4 @@ If the call stack depth is 1024, the call fails returning 1 as `status`, but the
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - The target address has more than 20 bytes.
+- Execution in a legacy (non-EOF) context.

--- a/docs/opcodes/FB.mdx
+++ b/docs/opcodes/FB.mdx
@@ -9,9 +9,13 @@ group: System operations
 
 Creates a new sub [context](/about) and execute the [code](/about) of the given account, then resumes the current one. Note that an account with no code will return success status.
 
-This instructions is equivalent to [EXTCALL](/#F8), except that it does not allow any state modifying instructions or sending ETH in the sub [context](/about). The disallowed instructions are [CREATE](/#F0), [CREATE2](/#F5), [LOG0](/#A0), [LOG1](/#A1), [LOG2](/#A2), [LOG3](/#A3), [LOG4](/#A4), [SSTORE](/#55), [SELFDESTRUCT](/#FF), [CALL](/#F1), and some EOF opcodes include [EOFCREATE](/#EC), [EXTCALL](/#F8) if the [value](/#34) sent is not 0.
+This instructions is equivalent to [EXTCALL](/#F8), except that it does not allow any state modifying instructions or sending ETH in the sub [context](/about). The disallowed instructions are [CREATE](/#F0), [CREATE2](/#F5), [LOG0](/#A0), [LOG1](/#A1), [LOG2](/#A2), [LOG3](/#A3), [LOG4](/#A4), [SSTORE](/#55), [SELFDESTRUCT](/#FF), [EOFCREATE](/#EC), as well as [CALL](/#F1) or [EXTCALL](/#F8) if the [value](/#34) sent is not 0.
 
-If the size of the [return data](/about) is not known, it can also be retrieved after the call with the instructions [RETURNDATASIZE](/#3D) and [RETURNDATACOPY](/#3E) (since the Byzantium fork), or load 32-byte word onto the stack with [RETURNDATALOAD](/#F7) instruction.
+The size of the [return data](/about) can be retrieved after the call with the instructions [RETURNDATASIZE](/#3D) and [RETURNDATACOPY](/#3E) (since the Byzantium fork), or load 32-byte word onto the stack with [RETURNDATALOAD](/#F7) instruction.
+
+All but one 64th (`remaining_gas / 64`) of the remaining gas of the current context is sent to the sub [context](/about) to execute, but no less than 2300. The gas that is not used by the sub context is returned to this one. In case gas not sent would be lower than 5000, the call fails returning 1 as `status`, but the current [context](/about) is not reverted.
+
+If the call stack depth is 1024, the call fails returning 1 as `status`, but the current [context](/about) is not reverted.
 
 ## Stack input
 
@@ -31,7 +35,4 @@ If the size of the [return data](/about) is not known, it can also be retrieved 
 
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
-- Not enough values on the stack.
-- Has positive value.
 - The target address has more than 20 bytes.
-- The target account code is legacy code (pre-EOF).

--- a/docs/opcodes/FF.mdx
+++ b/docs/opcodes/FF.mdx
@@ -24,4 +24,4 @@ Not allowed in EOFv1 code, code containing this instruction will fail validation
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Not enough values on the stack.
-- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since EOF fork).

--- a/docs/opcodes/FF.mdx
+++ b/docs/opcodes/FF.mdx
@@ -9,6 +9,8 @@ group: System operations
 From cancun behavior: send all Ether in the account to the target.
 If executed in the same transaction a contract was created, or pre-Cancun, the current account is registered to be destroyed, and will be at the end of the current transaction. The transfer of the current balance to the given account cannot fail. In particular, the destination account code (if any) is not executed, or, if the account does not exist, the balance is still added to the given address.
 
+Not allowed in EOFv1 code, code containing this instruction will fail validation.
+
 ## Stack input
 
 0. `address`: account to send the current balance to (see [BALANCE](/#31) or [SELFBALANCE](/#47) since Istanbul fork).
@@ -22,4 +24,4 @@ If executed in the same transaction a contract was created, or pre-Cancun, the c
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Not enough values on the stack.
-- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork).
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since Prague fork).

--- a/util/gas.ts
+++ b/util/gas.ts
@@ -238,14 +238,6 @@ const eofCreateCost = (common: EOFCommon, inputs: any): BN => {
     .iadd(new BN(inputs.executionCost))
     .iadd(depositCost)
 
-  if (common.gteHardfork('shanghai')) {
-    const initCodeCost = new BN(
-      toWordSize(new BN(inputs.containerSize)).imuln(
-        Number(getCommonParam(common, 'gasPrices', 'initCodeWordGas')),
-      ),
-    )
-    result.iadd(initCodeCost)
-  }
   return result
 }
 


### PR DESCRIPTION
First of all, thank you for adding EOF to evm.codes :bow:.

This is a first pass at fixing some details differing respect to current [EOF spec](https://eips.ethereum.org/EIPS/eip-7692), to my best recollection. Don't treat it as exhaustive yet.

I'm opening the PR as draft in order to get a round of reviews from the EOF team, in case I missed something or worded badly, but of course all feedback from maintainers is very welcome too :).

Here some comments on some of the changes:

- I remove the conditions from "## Error cases" which are validated for EOF in deploy time and as such impossible to occur at runtime. The sections' wording appears to refer strictly to runtime
- I suggest to add a section about instruction validation to each of the EOF instructions, but this is beyond the scope of the PR - requires discussion on how to approach this
- I admit I haven't tested the `.ts` change, assuming it should "just work", if there's any doubts, lmk