### PR TITLE
Fix issue with some opcodes crashing on linkage

### DIFF
--- a/components/ChainSelector.tsx
+++ b/components/ChainSelector.tsx
@@ -62,7 +62,6 @@ const ChainSelector = () => {
       : forkOptions.find((fork) => fork.value === CURRENT_FORK)
     if (fork) {
       setForkValue(fork as any)
-      onForkChange(fork.value)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router.isReady, defaultForkOption])

--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -241,7 +241,7 @@ const Editor = ({ readOnly = false }: Props) => {
       onForkChange(query.fork as string)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [settingsLoaded && router.isReady && isForksLoaded])
+  }, [settingsLoaded, router.isReady, isForksLoaded])
 
   useEffect(() => {
     solcWorkerRef.current = new Worker(

--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -82,7 +82,7 @@ const Editor = ({ readOnly = false }: Props) => {
     instructions,
     resetExecution,
     onForkChange,
-    isForksLoaded,
+    areForksLoaded,
   } = useContext(EthereumContext)
 
   const [code, setCode] = useState('')
@@ -241,7 +241,7 @@ const Editor = ({ readOnly = false }: Props) => {
       onForkChange(query.fork as string)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [settingsLoaded, router.isReady, isForksLoaded])
+  }, [settingsLoaded, router.isReady, areForksLoaded])
 
   useEffect(() => {
     solcWorkerRef.current = new Worker(

--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -82,6 +82,7 @@ const Editor = ({ readOnly = false }: Props) => {
     instructions,
     resetExecution,
     onForkChange,
+    isForksLoaded,
   } = useContext(EthereumContext)
 
   const [code, setCode] = useState('')
@@ -240,7 +241,7 @@ const Editor = ({ readOnly = false }: Props) => {
       onForkChange(query.fork as string)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [settingsLoaded && router.isReady])
+  }, [settingsLoaded && router.isReady && isForksLoaded])
 
   useEffect(() => {
     solcWorkerRef.current = new Worker(

--- a/components/Reference/index.tsx
+++ b/components/Reference/index.tsx
@@ -117,7 +117,7 @@ const ReferenceTable = ({
       onForkChange(query.fork as string)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.isReady && isForksLoaded])
+  }, [router.isReady, isForksLoaded])
 
   const renderExpandButton = () => {
     return (

--- a/components/Reference/index.tsx
+++ b/components/Reference/index.tsx
@@ -248,8 +248,8 @@ const ReferenceTable = ({
                             legacyBehavior
                             href={
                               isPrecompiled
-                                ? `/precompiled#${opcodeOrAddress}?fork=${selectedFork?.name}`
-                                : `/#${opcodeOrAddress}?fork=${selectedFork?.name}`
+                                ? `/precompiled?fork=${selectedFork?.name}#${opcodeOrAddress}`
+                                : `/?fork=${selectedFork?.name}#${opcodeOrAddress}`
                             }
                             passHref
                           >

--- a/components/Reference/index.tsx
+++ b/components/Reference/index.tsx
@@ -47,7 +47,8 @@ const ReferenceTable = ({
   isPrecompiled?: boolean
 }) => {
   const router = useRouter()
-  const { forks, selectedFork, onForkChange } = useContext(EthereumContext)
+  const { forks, selectedFork, onForkChange, isForksLoaded } =
+    useContext(EthereumContext)
   const data = useMemo(() => reference, [reference])
   const columns = useMemo(() => tableColumns(isPrecompiled), [isPrecompiled])
   const rowRefs = useRef<HTMLTableRowElement[]>([])
@@ -112,12 +113,11 @@ const ReferenceTable = ({
   // Change selectedFork according to query param
   useEffect(() => {
     const query = router.query
-
     if ('fork' in query) {
       onForkChange(query.fork as string)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.isReady])
+  }, [router.isReady && isForksLoaded])
 
   const renderExpandButton = () => {
     return (

--- a/components/Reference/index.tsx
+++ b/components/Reference/index.tsx
@@ -47,7 +47,7 @@ const ReferenceTable = ({
   isPrecompiled?: boolean
 }) => {
   const router = useRouter()
-  const { forks, selectedFork, onForkChange, isForksLoaded } =
+  const { forks, selectedFork, onForkChange, areForksLoaded } =
     useContext(EthereumContext)
   const data = useMemo(() => reference, [reference])
   const columns = useMemo(() => tableColumns(isPrecompiled), [isPrecompiled])
@@ -117,7 +117,7 @@ const ReferenceTable = ({
       onForkChange(query.fork as string)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.isReady, isForksLoaded])
+  }, [router.isReady, areForksLoaded])
 
   const renderExpandButton = () => {
     return (

--- a/context/ethereumContext.tsx
+++ b/context/ethereumContext.tsx
@@ -185,8 +185,6 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
    * Initializes the EVM instance.
    */
   const initVmInstance = async (fork?: string) => {
-    console.log({ fork })
-
     const forkName = fork == EOF_FORK_NAME ? EOF_ENABLED_FORK : fork
     common = new EOFCommon({
       chain: Chain.Mainnet,

--- a/context/ethereumContext.tsx
+++ b/context/ethereumContext.tsx
@@ -79,7 +79,7 @@ type ContextProps = {
   isExecuting: boolean
   executionState: IExecutionState
   vmError: string | undefined
-  isForksLoaded: boolean
+  areForksLoaded: boolean
 
   onChainChange: (chainId: number) => void
   onForkChange: (forkName: string) => void
@@ -126,7 +126,7 @@ export const EthereumContext = createContext<ContextProps>({
   isExecuting: false,
   executionState: initialExecutionState,
   vmError: undefined,
-  isForksLoaded: false,
+  areForksLoaded: false,
 
   onChainChange: () => undefined,
   onForkChange: () => undefined,
@@ -167,7 +167,7 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
     string | undefined
   >()
   const [vmError, setVmError] = useState<string | undefined>()
-  const [isForksLoaded, setIsForksLoaded] = useState<boolean>(false)
+  const [areForksLoaded, setareForksLoaded] = useState<boolean>(false)
 
   const nextStepFunction = useRef<any>()
   const isExecutionPaused = useRef(true)
@@ -176,7 +176,7 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
   useEffect(() => {
     void (async () => {
       await initVmInstance()
-      setIsForksLoaded(true)
+      setareForksLoaded(true)
     })()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
@@ -885,7 +885,7 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
         isExecuting,
         executionState,
         vmError,
-        isForksLoaded,
+        areForksLoaded,
 
         onChainChange,
         onForkChange,

--- a/context/ethereumContext.tsx
+++ b/context/ethereumContext.tsx
@@ -178,11 +178,7 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
   /**
    * Initializes the EVM instance.
    */
-  const initVmInstance = async (
-    skipChainsLoading?: boolean,
-    chainId?: Chain,
-    fork?: string,
-  ) => {
+  const initVmInstance = async (fork?: string) => {
     const forkName = fork == EOF_FORK_NAME ? EOF_ENABLED_FORK : fork
     common = new EOFCommon({
       chain: Chain.Mainnet,
@@ -198,7 +194,7 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
 
     currentOpcodes = evm.getActiveOpcodes()
 
-    if (!skipChainsLoading) {
+    if (forks.length === 0) {
       _loadChainAndForks(common)
     }
 
@@ -222,9 +218,12 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
   const onChainChange = (chainId: number) => {
     const chain = chains.find((chain) => chain.id === chainId)
     if (chain) {
-      setSelectedChain(chain)
-      resetExecution()
-      initVmInstance(true, chainId, selectedFork?.name)
+      void (async () => {
+        // NOTE: we first setup the vm to make sure it has the correct version before refreshing the fork details
+        await initVmInstance(selectedFork?.name)
+        setSelectedChain(chain)
+        resetExecution()
+      })()
     }
   }
 
@@ -235,9 +234,12 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
   const onForkChange = (forkName: string) => {
     const fork = forks.find((f) => f.name === forkName)
     if (fork) {
-      setSelectedFork(fork)
-      resetExecution()
-      initVmInstance(true, selectedChain?.id, forkName)
+      void (async () => {
+        // NOTE: we first setup the vm to make sure it has the correct version before refreshing the fork details
+        await initVmInstance(forkName)
+        setSelectedFork(fork)
+        resetExecution()
+      })()
     }
   }
 

--- a/context/ethereumContext.tsx
+++ b/context/ethereumContext.tsx
@@ -171,12 +171,7 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
   const breakpointIds = useRef<number[]>([])
 
   useEffect(() => {
-    _loadChainAndForks(
-      new Common({
-        chain: Chain.Mainnet,
-        hardfork: CURRENT_FORK,
-      }),
-    )
+    initVmInstance()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/context/ethereumContext.tsx
+++ b/context/ethereumContext.tsx
@@ -171,7 +171,12 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
   const breakpointIds = useRef<number[]>([])
 
   useEffect(() => {
-    initVmInstance()
+    _loadChainAndForks(
+      new Common({
+        chain: Chain.Mainnet,
+        hardfork: CURRENT_FORK,
+      }),
+    )
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/context/ethereumContext.tsx
+++ b/context/ethereumContext.tsx
@@ -167,7 +167,7 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
     string | undefined
   >()
   const [vmError, setVmError] = useState<string | undefined>()
-  const [areForksLoaded, setareForksLoaded] = useState<boolean>(false)
+  const [areForksLoaded, setAreForksLoaded] = useState<boolean>(false)
 
   const nextStepFunction = useRef<any>()
   const isExecutionPaused = useRef(true)
@@ -176,7 +176,7 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
   useEffect(() => {
     void (async () => {
       await initVmInstance()
-      setareForksLoaded(true)
+      setAreForksLoaded(true)
     })()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])

--- a/context/ethereumContext.tsx
+++ b/context/ethereumContext.tsx
@@ -79,6 +79,7 @@ type ContextProps = {
   isExecuting: boolean
   executionState: IExecutionState
   vmError: string | undefined
+  isForksLoaded: boolean
 
   onChainChange: (chainId: number) => void
   onForkChange: (forkName: string) => void
@@ -125,6 +126,7 @@ export const EthereumContext = createContext<ContextProps>({
   isExecuting: false,
   executionState: initialExecutionState,
   vmError: undefined,
+  isForksLoaded: false,
 
   onChainChange: () => undefined,
   onForkChange: () => undefined,
@@ -165,13 +167,17 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
     string | undefined
   >()
   const [vmError, setVmError] = useState<string | undefined>()
+  const [isForksLoaded, setIsForksLoaded] = useState<boolean>(false)
 
   const nextStepFunction = useRef<any>()
   const isExecutionPaused = useRef(true)
   const breakpointIds = useRef<number[]>([])
 
   useEffect(() => {
-    initVmInstance()
+    void (async () => {
+      await initVmInstance()
+      setIsForksLoaded(true)
+    })()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -179,6 +185,8 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
    * Initializes the EVM instance.
    */
   const initVmInstance = async (fork?: string) => {
+    console.log({ fork })
+
     const forkName = fork == EOF_FORK_NAME ? EOF_ENABLED_FORK : fork
     common = new EOFCommon({
       chain: Chain.Mainnet,
@@ -234,7 +242,7 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
   const onForkChange = (forkName: string) => {
     const fork = forks.find((f) => f.name === forkName)
     if (fork) {
-      void (async () => {
+      ;(async () => {
         // NOTE: we first setup the vm to make sure it has the correct version before refreshing the fork details
         await initVmInstance(forkName)
         setSelectedFork(fork)
@@ -879,6 +887,7 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
         isExecuting,
         executionState,
         vmError,
+        isForksLoaded,
 
         onChainChange,
         onForkChange,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "scripts": {
     "build": "next build",
-    "serve": "next start",
     "build:solcjs-worker": "npx -y browserify -t babelify ./babel/solcWorker2.js > ./public/solcWorker.js",
     "dev": "pnpm run build:solcjs-worker && next dev",
     "format": "prettier --write  --cache .",
@@ -106,14 +105,14 @@
     "typescript": "^5.0.4",
     "webpack": "^5.90.3"
   },
-  "packageManager": "pnpm@9.4.0",
+  "packageManager": "pnpm@8.15.6",
   "engines": {
     "node": "^20.0.0",
-    "pnpm": "^9.4.0"
+    "pnpm": "^8.15.6"
   },
   "volta": {
     "node": "20.12.2",
-    "pnpm": "9.4.0"
+    "pnpm": "8.15.6"
   },
   "pnpm": {
     "allowedDeprecatedVersions": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build": "next build",
+    "serve": "next start",
     "build:solcjs-worker": "npx -y browserify -t babelify ./babel/solcWorker2.js > ./public/solcWorker.js",
     "dev": "pnpm run build:solcjs-worker && next dev",
     "format": "prettier --write  --cache .",
@@ -105,14 +106,14 @@
     "typescript": "^5.0.4",
     "webpack": "^5.90.3"
   },
-  "packageManager": "pnpm@8.15.6",
+  "packageManager": "pnpm@9.4.0",
   "engines": {
     "node": "^20.0.0",
-    "pnpm": "^8.15.6"
+    "pnpm": "^9.4.0"
   },
   "volta": {
     "node": "20.12.2",
-    "pnpm": "8.15.6"
+    "pnpm": "9.4.0"
   },
   "pnpm": {
     "allowedDeprecatedVersions": {

--- a/pages/precompiled.tsx
+++ b/pages/precompiled.tsx
@@ -28,7 +28,7 @@ const PrecompiledPage = ({
   precompiledDocs: IItemDocs
   gasDocs: IGasDocs
 }) => {
-  const { precompiled, onForkChange, isForksLoaded } =
+  const { precompiled, onForkChange, areForksLoaded } =
     useContext(EthereumContext)
 
   // Change selectedFork according to query param
@@ -41,7 +41,7 @@ const PrecompiledPage = ({
       onForkChange(query.fork as string)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.isReady, isForksLoaded])
+  }, [router.isReady, areForksLoaded])
 
   return (
     <>

--- a/pages/precompiled.tsx
+++ b/pages/precompiled.tsx
@@ -41,7 +41,7 @@ const PrecompiledPage = ({
       onForkChange(query.fork as string)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.isReady && isForksLoaded])
+  }, [router.isReady, isForksLoaded])
 
   return (
     <>

--- a/pages/precompiled.tsx
+++ b/pages/precompiled.tsx
@@ -28,7 +28,8 @@ const PrecompiledPage = ({
   precompiledDocs: IItemDocs
   gasDocs: IGasDocs
 }) => {
-  const { precompiled, onForkChange } = useContext(EthereumContext)
+  const { precompiled, onForkChange, isForksLoaded } =
+    useContext(EthereumContext)
 
   // Change selectedFork according to query param
   const router = useRouter()
@@ -40,7 +41,7 @@ const PrecompiledPage = ({
       onForkChange(query.fork as string)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.isReady])
+  }, [router.isReady && isForksLoaded])
 
   return (
     <>

--- a/util/compiler.ts
+++ b/util/compiler.ts
@@ -4,7 +4,7 @@ import { IInstruction, IReferenceItem } from 'types'
 import { EOF_FORK_NAME } from './constants'
 
 // Version here: https://github.com/ethereum/solc-bin/blob/gh-pages/bin/list.txt
-export const compilerVersion = `soljson-v0.8.27-nightly.2024.8.29+commit.ae1c3d48`
+export const compilerVersion = `soljson-v0.8.27+commit.40a35a09`
 
 /**
  * Gets target EVM version from a hardfork name


### PR DESCRIPTION
Fixes
- Reported issue by user #345 
- Links to opcodes not working if a fork was selected
- Forks not loading correctly because of race condition where forks were loaded after `onfork` was called. Fixed by adding a new field to the context.

Some of the underlying logic related to this should be re-worked as it's called from multiple places, but that is not in scope for this PR. 

## Test plan
1. Opening shared opcodes should not crash app (example from issue) 
      - (preview build works) https://evm-codes-git-hotfix-fix-link-crash-smlxl.vercel.app/?fork=cancun#f3 
      - (prod fails) https://evm.codes/?fork=cancun#f3
      - <img width="1269" alt="Screenshot 2024-09-16 at 19 10 40" src="https://github.com/user-attachments/assets/264ff121-67ea-460d-b159-d3b78a88f6d0">

2. Fork selector should still work
      - https://evm-codes-git-hotfix-fix-link-crash-smlxl.vercel.app/?fork=grayGlacier should not show `PUSH0`
      - https://evm-codes-git-hotfix-fix-link-crash-smlxl.vercel.app/?fork=shanghai should show `PUSH0` as it was added here 
      - <img width="1415" alt="Screenshot 2024-09-16 at 13 19 50" src="https://github.com/user-attachments/assets/9161eb32-70b5-4d93-be2f-b556000c06c0">

3. EOF opcode linking should also work
      - https://evm-codes-git-hotfix-fix-link-crash-smlxl.vercel.app/?fork=EOF#ec
      - https://evm-codes-git-hotfix-fix-link-crash-smlxl.vercel.app/?fork=EOF#f9
      - https://evm-codes-git-hotfix-fix-link-crash-smlxl.vercel.app/?fork=EOF#f3

4. Precompiles linking should also work
     - https://evm-codes-git-hotfix-fix-link-crash-smlxl.vercel.app/precompiled?fork=EOF#0x0a
         - Should show 0x0a as it was added later on 
     - https://evm-codes-git-hotfix-fix-link-crash-smlxl.vercel.app/precompiled?fork=cancun#0x0a
         - Should show 0x0a as it was added later on 
     - https://evm-codes-git-hotfix-fix-link-crash-smlxl.vercel.app/precompiled?fork=london#0x08
         - Should not show 0x0a as it was added later on 
         - <img width="1410" alt="Screenshot 2024-09-16 at 16 10 57" src="https://github.com/user-attachments/assets/56fa4f2e-8f32-4638-92d2-a1060b4f49c6">
