### PR TITLE
Grammar and Wording Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Install the dependencies:
 
     pnpm install
 
-Specify the environment variables if you want to run the contract viewer into `.env.local`
+Specify the environment variables if you want to run the contract viewer in `.env.local`
 
     APIKEY_ETHERSCAN=
 

--- a/components/ui/vector/README.md
+++ b/components/ui/vector/README.md
@@ -7,7 +7,7 @@ The project uses [Remix Icons](https://remixicon.com/), so if you are adding new
 3. Go to [Icomoon](https://icomoon.io/), create an empty set and upload all the SVGs you downloaded previously.
 4. Select all icons, click "Generate SVG & More" and open preferences (gear icon near the Download button).
 5. Here, for the _Name_ enter `remix`, and for the _Class Prefix_ enter `ri-`.
-6. Download Icomoon pack, follow these commands to generate a React component with all the icons includes as SVG defs:
+6. Download Icomoon pack, follow these commands to generate a React component with all the icons included as SVG defs:
 
 ```
 unzip remix.zip

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,7 +36,7 @@ The dynamic gas fee calculation is handled by the following pieces of code:
 
 1. The actual gas calculation is performed by the [util/gas.ts#calculateDynamicFee](../util/gas.ts) based on the selected [EthereumJS Common](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/common) object, via the get `param` method.
 
-1. Opcode with dynamic gas fee portion in [docs/opcodes](../docs/opcodes) can then have fork specific documentation (for example, `0A/london.mdx`), which are picked by the [components/Reference/DocRow.tsx](../components/Reference/DocRow.tsx) depending on the selected hardfork. In case of multiple hardfork docs, the latest to the selected one is picked. Additionally, these Markdown documents may have dynamic variables that are processed client-side and converted to MDX server-side by the [api/getDynamicDoc.ts](../pages/api/getDynamicDoc.ts) (due to node module dependencies of the `next-mdx-remote` package).
+1.An Opcode with dynamic gas fee portion in [docs/opcodes](../docs/opcodes) can then have fork specific documentation (for example, `0A/london.mdx`), which are picked by the [components/Reference/DocRow.tsx](../components/Reference/DocRow.tsx) depending on the selected hardfork. In case of multiple hardfork docs, the latest to the selected one is picked. Additionally, these Markdown documents may have dynamic variables that are processed client-side and converted to MDX server-side by the [api/getDynamicDoc.ts](../pages/api/getDynamicDoc.ts) (due to node module dependencies of the `next-mdx-remote` package).
 
 ### Supported dynamic variables
 


### PR DESCRIPTION


## Changes Made

### 1. In `README.md`:
- Old: "Specify the environment variables if you want to run the contract viewer into `.env.local`"
- New: "Specify the environment variables if you want to run the contract viewer in `.env.local`"

**Reason**: The preposition "into" was incorrect in this context. "in" is the proper preposition when referring to specifying variables in a file.

### 2. In `components/ui/vector/README.md`:
- Old: "Download Icomoon pack, follow these commands to generate a React component with all the icons includes as SVG defs:"
- New: "Download Icomoon pack, follow these commands to generate a React component with all the icons included as SVG defs:"

**Reason**: "includes" was incorrectly used as a past participle. "included" is the correct past participle form when used as an adjective.

### 3. In `docs/ARCHITECTURE.md`:
- Old: "Opcode with dynamic gas fee portion"
- New: "An Opcode with dynamic gas fee portion"

**Reason**: Added the indefinite article "An" at the beginning of the sentence for proper English grammar, as it's required before singular countable nouns.

## Summary
These changes improve the grammatical accuracy of the documentation, making it more professional and easier to understand for all users. The modifications focus on proper preposition usage, correct verb forms, and appropriate article placement.