### PR TITLE
Refine grammar, clarity, and precision in documentation

### DIFF
--- a/docs/opcodes/03.mdx
+++ b/docs/opcodes/03.mdx
@@ -8,7 +8,7 @@ group: Stop and Arithmetic Operations
 ## Stack input
 
 0. `a`: first integer value.
-1. `b`: integer value to subtract to the first.
+1. `b`: integer value to subtract from the first.
 
 ## Stack output
 

--- a/docs/opcodes/05.mdx
+++ b/docs/opcodes/05.mdx
@@ -16,7 +16,7 @@ All values are treated as two’s complement signed 256-bit integers. Note the o
 
 ## Stack output
 
-0. `a // b`: integer result of the signed integer division. If the denominator is 0, the result will be 0.
+0. `a // b`: signed integer division result. If the denominator is 0, the result will be 0.
 
 ## Examples
 

--- a/docs/opcodes/06.mdx
+++ b/docs/opcodes/06.mdx
@@ -12,8 +12,7 @@ group: Stop and Arithmetic Operations
 
 ## Stack output
 
-0. `a % b`: integer result of the integer modulo. If the denominator is 0, the result will be 0.
-
+0. `a % b`: integer result of the integer modulo. If the denominator equals 0, the result is 0.
 ## Examples
 
 | * | Input | Output | * | * | Input | Output |

--- a/docs/opcodes/06.mdx
+++ b/docs/opcodes/06.mdx
@@ -13,6 +13,7 @@ group: Stop and Arithmetic Operations
 ## Stack output
 
 0. `a % b`: integer result of the integer modulo. If the denominator equals 0, the result is 0.
+
 ## Examples
 
 | * | Input | Output | * | * | Input | Output |

--- a/docs/opcodes/07.mdx
+++ b/docs/opcodes/07.mdx
@@ -7,7 +7,7 @@ group: Stop and Arithmetic Operations
 
 ## Notes
 
-All values are treated as two’s complement signed 256-bit integers. Note the overflow semantic when −2<sup>255</sup> is negated.
+All values are treated as two's complement 256-bit signed integers. Note the overflow semantic when −2<sup>255</sup> is negated.
 
 ## Stack input
 

--- a/docs/opcodes/0B.mdx
+++ b/docs/opcodes/0B.mdx
@@ -7,7 +7,7 @@ group: Stop and Arithmetic Operations
 
 ## Stack input
 
-0. `b`: size in byte - 1 of the integer to sign extend.
+0. `b`: size in byte - 1 of the integer to be sign-extended.
 1. `x`: integer value to sign extend.
 
 ## Stack output


### PR DESCRIPTION
Fixed:

Replaced to with from for accuracy.
Simplified integer result of the signed integer division to signed integer division result.
Updated If the denominator is 0, the result will be 0. to If the denominator equals 0, the result is 0. for improved clarity.
Clarified All values are treated as two’s complement signed to All values are treated as two's complement 256-bit signed for precision.
Changed to sign extend to to be sign-extended for grammatical correctness.
Why it's useful:
These changes enhance precision, grammatical accuracy, and readability, making the text clearer and more professional.