### PR TITLE
Fix Grammar Issues in EVM Opcode Documentation

### DIFF
--- a/docs/opcodes/E1.mdx
+++ b/docs/opcodes/E1.mdx
@@ -13,7 +13,7 @@ The **RJUMPI** instruction may alter the program counter with relative offset, t
 
 ## Stack input
 
-0. `condition`: value that pop from the stack, define how program counter will altered.
+0. `condition`: value that popped from the stack, define how program counter will altered.
 
 ## Immediate argument
 

--- a/docs/opcodes/E1.mdx
+++ b/docs/opcodes/E1.mdx
@@ -13,7 +13,7 @@ The **RJUMPI** instruction may alter the program counter with relative offset, t
 
 ## Stack input
 
-0. `condition`: value that popped from the stack, define how program counter will altered.
+0. `condition`: value that is popped from the stack, define how program counter will altered.
 
 ## Immediate argument
 

--- a/docs/opcodes/E2.mdx
+++ b/docs/opcodes/E2.mdx
@@ -13,11 +13,11 @@ The **RJUMPV** instruction may alter the program counter with relative offset, t
 
 An interesting feature is that `RJUMPV 0 relative_offset` is an inverted-[RJUMPI](/#E1), which can be used in many cases instead of `ISZERO RJUMPI relative_offset`.
 
-It offer reduced gas cost (both at deploy and execution time) and better analysis properties.
+It offers reduced gas cost (both at deploy and execution time) and better analysis properties.
 
 ## Stack input 
 
-0. `case`: value that pop from the stack, used to compare with max index, and define how program counter will altered.
+0. `case`: value that is popped from the stack, used to compare with max index, and define how program counter will altered.
 
 ## Immediate argument
 


### PR DESCRIPTION
Rationale:
1. Fixed passive voice usage ("pop" -> "is popped") for better grammar
2. Corrected subject-verb agreement ("offer" -> "offers")