### PR TITLE
chore: Add more details for reverting STATICCALL sub context

### DIFF
--- a/docs/opcodes/FA.mdx
+++ b/docs/opcodes/FA.mdx
@@ -35,3 +35,5 @@ Not allowed in EOFv1 code, code containing this instruction will fail validation
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Not enough values on the stack.
+
+The state changes done by the sub context are [reverted](#FD) and all the remaining gas in the sub context is consumed if any of the disallowed state modifying instructions (see list above) is used by the sub context.


### PR DESCRIPTION
When a state-modifying opcode is executed in the context of STATICCALL, the `WriteInStaticContext` exception is raised as one can see in [SSTORE](https://github.com/ethereum/execution-specs/blob/master/src/ethereum/cancun/vm/instructions/storage.py#L125).

This exception is an `ExceptionalHalt`, see [here](https://github.com/ethereum/execution-specs/blob/master/src/ethereum/cancun/vm/exceptions.py#L93).

An `ExceptionalHalt` will consume all remaining gas as seen [here](https://github.com/ethereum/execution-specs/blob/master/src/ethereum/cancun/vm/interpreter.py#L310).