### PR TITLE
fix: bump etherscan api to v2

### DIFF
--- a/util/EtherscanApi.ts
+++ b/util/EtherscanApi.ts
@@ -1,4 +1,4 @@
-const ETHERSCAN_URL = 'https://api.etherscan.io/api?'
+const ETHERSCAN_URL = 'https://api.etherscan.io/v2/api?'
 
 export async function etherscanRequest(
   module: string,
@@ -6,6 +6,7 @@ export async function etherscanRequest(
   params: object,
 ) {
   const query: any = {
+    chainid: 1,
     apikey: process.env.APIKEY_ETHERSCAN,
     module: module,
     action: action,

--- a/util/EtherscanApi.ts
+++ b/util/EtherscanApi.ts
@@ -1,19 +1,23 @@
-const ETHERSCAN_URL = 'https://api.etherscan.io/v2/api?'
+const ETHERSCAN_URL = 'https://api.etherscan.io/v2/api'
+const ETHERSCAN_CHAIN_ID = process.env.ETHERSCAN_CHAIN_ID || '1'
 
 export async function etherscanRequest(
   module: string,
   action: string,
   params: object,
 ) {
-  const query: any = {
-    chainid: 1,
-    apikey: process.env.APIKEY_ETHERSCAN,
+  const query: Record<string, string> = {
+    chainid: ETHERSCAN_CHAIN_ID,
+    apikey: process.env.APIKEY_ETHERSCAN || '',
     module: module,
     action: action,
-    ...params,
   }
 
-  const url = ETHERSCAN_URL + new URLSearchParams(query)
+  Object.entries(params).forEach(([key, value]) => {
+    query[key] = String(value)
+  })
+
+  const url = `${ETHERSCAN_URL}?${new URLSearchParams(query)}`
   return fetch(url)
 }
 

--- a/util/EtherscanParser.ts
+++ b/util/EtherscanParser.ts
@@ -11,7 +11,9 @@ export function etherscanParse(
   response: EtherscanResponse,
 ): EtherscanContractResponse {
   if (response.message !== 'OK') {
-    throw 'etherscan response is not OK'
+    const reason =
+      typeof response.result === 'string' ? response.result : response.message
+    throw `etherscan response is not OK: ${reason}`
   }
 
   if (!response.result || response.result.length == 0) {


### PR DESCRIPTION
The use of version 2 of the Etherscan API is now mandatory. 
This update is required for the contract viewer page to function.