### PR TITLE
fix: support osaka compilation with Solidity 0.8.31

### DIFF
--- a/util/compiler.ts
+++ b/util/compiler.ts
@@ -4,7 +4,7 @@ import { IInstruction, IReferenceItem } from 'types'
 import { EOF_FORK_NAME } from './constants'
 
 // Version here: https://github.com/ethereum/solc-bin/blob/gh-pages/bin/list.txt
-export const compilerVersion = `soljson-v0.8.27+commit.40a35a09`
+export const compilerVersion = `soljson-v0.8.31+commit.fd3a2265`
 
 /**
  * Gets target EVM version from a hardfork name


### PR DESCRIPTION
## Summary
This updates the playground Solidity compiler to a version that supports Osaka-compatible contracts requiring Solidity `^0.8.31`.

## Changes
- `util/compiler.ts`
- Set default compiler to `soljson-v0.8.31+commit.fd3a2265`
- Keep EOF mapping behavior (`EOF` -> `prague`) while preserving normal hardfork passthrough

## Why
`fork=osaka` compilation failed for newer contracts and Osaka-specific assembly paths when the playground was pinned to `0.8.27`.

Closes #409
