### PR TITLE
Fix API method guards

### DIFF
--- a/pages/api/getContract.ts
+++ b/pages/api/getContract.ts
@@ -7,11 +7,12 @@ export default async function handler(
   res: NextApiResponse,
 ) {
   if (req.method !== 'GET') {
-    res.status(405)
+    res.setHeader('Allow', ['GET'])
+    return res.status(405).json({ error: 'Method Not Allowed' })
   }
 
   const addr = req.query?.address as string
   const ethscan_resp = await etherscanGetSource(addr)
   const data = await ethscan_resp.json()
-  res.status(200).json(data)
+  return res.status(200).json(data)
 }

--- a/pages/api/getDynamicDoc.ts
+++ b/pages/api/getDynamicDoc.ts
@@ -5,10 +5,11 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
 ) {
-  if (req.method === 'POST') {
-    const { body } = req
-    res.status(200).json({ mdx: await serialize(body.content) })
-  } else {
-    res.status(405)
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST'])
+    return res.status(405).json({ error: 'Method Not Allowed' })
   }
+
+  const { body } = req
+  return res.status(200).json({ mdx: await serialize(body.content) })
 }


### PR DESCRIPTION
## Summary
- return immediately from API routes when the request method is not supported
- include Allow headers for the supported methods
- avoid calling Etherscan from /api/getContract after rejecting a non-GET request

## Validation
- reproduced the existing /api/getContract behavior: POST returned 200 and still called Etherscan
- verified the patched behavior: unsupported methods return 405 and do not continue handler work
- pnpm run typecheck
- pnpm exec eslint pages/api/getContract.ts pages/api/getDynamicDoc.ts
- pnpm exec prettier --check pages/api/getContract.ts pages/api/getDynamicDoc.ts
- pnpm run build