### PR TITLE
Fix Osaka playground compilation

### DIFF
--- a/util/compiler.ts
+++ b/util/compiler.ts
@@ -27,7 +27,7 @@ export const getTargetEvmVersion = (forkName: string | undefined) => {
     )
   ) {
     return 'london'
-  } else if (forkName === EOF_FORK_NAME) {
+  } else if (forkName === 'osaka' || forkName === EOF_FORK_NAME) {
     return 'prague'
   }
   return forkName


### PR DESCRIPTION
## Summary

Fixes playground compilation when Osaka is selected by mapping the Osaka hardfork to the latest EVM target supported by the pinned Solidity compiler.

Solidity 0.8.27 supports `prague` as an EVM target, but not `osaka`, so passing `osaka` caused compilation to fail with `Invalid EVM version requested`.

## Test plan

- Open `/playground`
- Keep the default Osaka fork selected
- Press Run
- Confirm compilation succeeds instead of failing with `Invalid EVM version requested`