### PR TITLE
fix: clarify precompile address allocation

### DIFF
--- a/pages/precompiled.tsx
+++ b/pages/precompiled.tsx
@@ -64,15 +64,15 @@ const PrecompiledPage = ({
           On top of having a set of opcodes to choose from, the EVM also offers
           a set of more advanced functionalities through precompiled contracts.
           These are a special kind of contracts that are bundled with the EVM at
-          fixed addresses, and can be called with a determined gas cost. The
-          addresses start from 1, and increment for each contract. New hardforks
-          may introduce new precompiled contracts. They are called from the
-          opcodes like regular contracts, with instructions like{' '}
-          <Link to="#F1" title="CALL" />. The gas cost mentioned here is purely
-          the cost of the contract, and does not consider the cost of the call
-          itself nor the instructions to put the parameters in memory. The
-          precompiled contracts are also available in the{' '}
-          <Link to="playground" title="playground" />.
+          fixed addresses, and can be called with a determined gas cost. Early
+          precompiled contracts use sequential addresses starting from 1, while
+          new hardforks may introduce precompiled contracts at non-contiguous
+          addresses. They are called from the opcodes like regular contracts,
+          with instructions like <Link to="#F1" title="CALL" />. The gas cost
+          mentioned here is purely the cost of the contract, and does not
+          consider the cost of the call itself nor the instructions to put the
+          parameters in memory. The precompiled contracts are also available in
+          the <Link to="playground" title="playground" />.
         </p>
         <p className="pb-6">
           For all precompiled contracts, if the input is shorter than expected,


### PR DESCRIPTION
Fixes #417.

The precompiled contracts introduction said that addresses start from 1 and increment for each contract. That is true for the early precompiles, but no longer accurate for the full table now that newer hardforks include non-contiguous addresses such as `0x100` for `P256VERIFY`.

This updates the wording to say that early precompiles use sequential addresses starting from 1, while newer hardforks may introduce precompiles at non-contiguous addresses.


 I have verify this change by executing:

- `pnpm exec prettier --check pages/precompiled.tsx`
- `pnpm exec eslint --ext js,jsx,ts,tsx pages/precompiled.tsx`
- `pnpm typecheck`