### PR TITLE
Fix: Update link in about.tsx to new chapter location

### DIFF
--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -495,7 +495,7 @@ const AboutPage = () => {
           </a>
           ,{' '}
           <a
-            href="https://github.com/ethereumbook/ethereumbook/blob/develop/13evm.asciidoc"
+            href="https://github.com/ethereumbook/ethereumbook/blob/develop/src/chapter_14.md"
             target="_blank"
             rel="noreferrer"
             className="underline"


### PR DESCRIPTION
Fixes broken `The EVM Chapter in the Mastering Ethereum book` link

Old link: [The EVM Chapter in the Mastering Ethereum book](https://github.com/ethereumbook/ethereumbook/blob/develop/13evm.asciidoc)
New link: [The EVM Chapter in the Mastering Ethereum book](https://github.com/ethereumbook/ethereumbook/blob/develop/src/chapter_14.md)