### PR TITLE
fix: clean up spacing in PREVRANDAO documentation

### DIFF
--- a/docs/opcodes/44_merge.mdx
+++ b/docs/opcodes/44_merge.mdx
@@ -7,7 +7,7 @@ group: Block Information
 
 ## Stack output
 
-0. `prevRandao`: previous  block's [RANDAO  mix](https://eips.ethereum.org/EIPS/eip-4399).
+0. `prevRandao`: previous block's [RANDAO mix](https://eips.ethereum.org/EIPS/eip-4399).
 
 ## Example
 


### PR DESCRIPTION
Remove accidental extra spaces from the PREVRANDAO stack output description.

This changes “previous  block's RANDAO  mix” to “previous block's RANDAO mix”, improving readability and keeping the documentation formatting consistent.
